### PR TITLE
Read SideNav information from graphql

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -197,7 +197,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
   const openapiTemplate = path.resolve(`src/templates/openapiTemplate.js`)
   const indexTemplate = path.resolve(`src/templates/indexTemplate.js`)
 
-  const pages = await readManifest(graphql)
   const gitRemote = gitRepoInfo(graphql)
 
   try {
@@ -221,7 +220,8 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     if (data) {
       data.allMarkdownRemark.edges.forEach(({ node }) => {
         if (node.fields.slug !== "") {
-          let seo = searchTree(pages, node.fields.slug)
+          // let seo = searchTree(pages, node.fields.slug)
+          let seo = "Fix SEO"
           if (node.frontmatter.template === "recipe") {
             createPage({
               path: node.fields.slug,
@@ -231,7 +231,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
                 id: node.fields.id,
                 seo: seo,
                 gitRemote: gitRemote,
-                pages: pages,
               },
             })
           } else {
@@ -243,7 +242,6 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
                 id: node.fields.id,
                 seo: seo,
                 gitRemote: gitRemote,
-                pages: pages,
               },
             })
           }
@@ -273,15 +271,15 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       jsonData.allFile.edges.forEach(({ node }) => {
         let filepath = node.absolutePath
         const object = JSON.parse(fs.readFileSync(filepath, "utf8"))
-        let seo = searchTree(pages, `${node.name}${node.ext}`)
+        // let seo = searchTree(pages, `${node.name}${node.ext}`)
+        let seo = "Fix SEO"
         createOpenApiPage(
           createPage,
           openapiTemplate,
           object,
           filepath,
           seo,
-          gitRemote,
-          pages
+          gitRemote
         )
       })
     }
@@ -309,15 +307,15 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         let filepath = node.absolutePath
         try {
           let object = YAML.parse(fs.readFileSync(filepath, "utf8"))
-          let seo = searchTree(pages, `${node.name}${node.ext}`)
+          // let seo = searchTree(pages, `${node.name}${node.ext}`)
+          let seo = "Fix SEO"
           createOpenApiPage(
             createPage,
             openapiTemplate,
             object,
             filepath,
             seo,
-            gitRemote,
-            pages
+            gitRemote
           )
         } catch (e) {
           console.log(`Skipping file: ${filepath}`)
@@ -367,8 +365,7 @@ const createOpenApiPage = (
   object,
   filepath,
   seo,
-  gitRemote,
-  pages
+  gitRemote
 ) => {
   if (object.swagger || object.openapi) {
     let slug = filepath
@@ -376,7 +373,9 @@ const createOpenApiPage = (
     switch (environment) {
       case "production":
         if (filepath.lastIndexOf("gatsby-source-git/") > -1) {
-          slug = filepath.substring(filepath.lastIndexOf("gatsby-source-git/") + 18)
+          slug = filepath.substring(
+            filepath.lastIndexOf("gatsby-source-git/") + 18
+          )
         }
         break
       case "development":
@@ -436,7 +435,6 @@ const createOpenApiPage = (
         spec: object,
         seo: seo,
         gitRemote: gitRemote,
-        pages: pages,
       },
     })
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,35 +28,6 @@ const GitUrlParse = require(`git-url-parse`)
 
 const environment = process.env.NODE_ENV || "development"
 
-const stripManifestPath = (path, { org = "", name = "", branch = "" } = {}) => {
-  if (!path) {
-    return ""
-  }
-  let urlPrefix = ""
-  if (org) {
-    urlPrefix += org
-  }
-  if (name) {
-    urlPrefix += urlPrefix !== "" ? "/" + name : name
-  }
-  if (branch) {
-    urlPrefix += urlPrefix !== "" ? "/" + branch : branch
-  }
-  // Normal case with org/name/branch
-  let location = path.toLowerCase().indexOf(urlPrefix.toLowerCase())
-  if (location > -1) {
-    return path.substring(location + urlPrefix.length)
-  }
-  // Exception case with only name in url
-  else if (path.toLowerCase().indexOf(name.toLowerCase() > -1)) {
-    return path.substring(
-      path.toLowerCase().indexOf(name.toLowerCase()) + name.length
-    )
-  } else {
-    return path
-  }
-}
-
 const searchTree = (theObject, matchingFilename) => {
   var result = null
   if (theObject instanceof Array) {
@@ -87,38 +58,6 @@ const searchTree = (theObject, matchingFilename) => {
   return result
 }
 
-const readManifest = async graphql => {
-  let pages = []
-  try {
-    let { data } = await graphql(`
-      query {
-        allFile(filter: { extension: { eq: "json" } }) {
-          edges {
-            node {
-              absolutePath
-            }
-          }
-        }
-      }
-    `)
-
-    if (data) {
-      data.allFile.edges.forEach(({ node }) => {
-        let path = node.absolutePath
-        const object = JSON.parse(fs.readFileSync(path, "utf8"))
-        if (object.view_type === "mdbook") {
-          pages = object.pages
-        }
-      })
-    }
-  } catch (e) {
-    console.log(e)
-    console.log("Could not read the manifest")
-  }
-
-  return pages
-}
-
 const gitRepoInfo = () => {
   const gitInfo = GitUrlParse(process.env.GATSBY_SOURCE)
   return {
@@ -129,20 +68,6 @@ const gitRepoInfo = () => {
     name: gitInfo.name,
     ref: process.env.GATSBY_SOURCE_BRANCH,
   }
-}
-
-const findHomePage = element => {
-  let result = null
-  if (element.path) {
-    return element
-  } else if (element.pages !== null) {
-    for (let j = 0; result === null && j < element.pages.length; j++) {
-      result = findHomePage(element.pages[j])
-    }
-    return result
-  }
-
-  return result
 }
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
@@ -215,13 +140,18 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             }
           }
         }
+        parliamentNavigation {
+          pages
+        }
       }
     `)
     if (data) {
       data.allMarkdownRemark.edges.forEach(({ node }) => {
         if (node.fields.slug !== "") {
-          // let seo = searchTree(pages, node.fields.slug)
-          let seo = "Fix SEO"
+          let seo = searchTree(
+            data.parliamentNavigation.pages,
+            node.fields.slug
+          )
           if (node.frontmatter.template === "recipe") {
             createPage({
               path: node.fields.slug,
@@ -265,14 +195,19 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             }
           }
         }
+        parliamentNavigation {
+          pages
+        }
       }
     `)
     if (jsonData.allFile.edges.length > 0) {
       jsonData.allFile.edges.forEach(({ node }) => {
         let filepath = node.absolutePath
         const object = JSON.parse(fs.readFileSync(filepath, "utf8"))
-        // let seo = searchTree(pages, `${node.name}${node.ext}`)
-        let seo = "Fix SEO"
+        let seo = searchTree(
+          jsonData.parliamentNavigation.pages,
+          `${node.name}${node.ext}`
+        )
         createOpenApiPage(
           createPage,
           openapiTemplate,
@@ -300,6 +235,9 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             }
           }
         }
+        parliamentNavigation {
+          pages
+        }
       }
     `)
     if (yamlData.allFile.edges.length > 0) {
@@ -307,8 +245,10 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         let filepath = node.absolutePath
         try {
           let object = YAML.parse(fs.readFileSync(filepath, "utf8"))
-          // let seo = searchTree(pages, `${node.name}${node.ext}`)
-          let seo = "Fix SEO"
+          let seo = searchTree(
+            yamlData.parliamentNavigation.pages,
+            `${node.name}${node.ext}`
+          )
           createOpenApiPage(
             createPage,
             openapiTemplate,
@@ -328,35 +268,18 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
   }
 
   // redirect home page to main page
-  // const homePage = pages[0]
-  let homePage = null
-  for (let i = 0; i < pages.length; i++) {
-    homePage = findHomePage(pages[i])
-    if (homePage !== null) {
-      break
-    }
-  }
-
-  const strippedHomePage = stripManifestPath(homePage.path, {
-    org: gitRemote.organization,
-    name: gitRemote.name,
-    branch: gitRemote.ref,
-  })
   createPage({
     path: `/`,
     component: indexTemplate,
     context: {
       slug: `/`,
-      redirect: strippedHomePage,
+      gitRemote: {
+        org: gitRemote.organization,
+        name: gitRemote.name,
+        branch: gitRemote.ref,
+      },
     },
   })
-
-  // Setup cypress.env.json for testing
-  const cypress = {
-    prefix: process.env.GATSBY_SITE_PATH_PREFIX,
-    homePage: strippedHomePage,
-  }
-  fs.writeFileSync("cypress.env.json", JSON.stringify(cypress))
 }
 
 const createOpenApiPage = (

--- a/plugins/navigation-files-transformer/gatsby-node.js
+++ b/plugins/navigation-files-transformer/gatsby-node.js
@@ -1,6 +1,6 @@
-const { GraphQLJSON } = require("gatsby/graphql")
 const fromJson = require("./src/fromJson")
 const fromYaml = require("./src/fromYaml")
+const reduceGraphQLToJson = require("./src/utils")
 
 /**
  * Callback for creating graphql nodes from project navigation files.
@@ -55,15 +55,22 @@ const onCreateNode = async (
   }
 }
 
-exports.setFieldsOnGraphQLNodeType = args => {
-  const {
-    type: { name, nodes },
-  } = args
+/**
+ * Called during the creation of the GraphQL schema.
+ * Allows plugins to add new fields to the types created from data nodes.
+ * It will be called separately for each type.
+ * This function should return an object in the shape of GraphQLFieldConfigMap
+ * which will be appended to fields inferred by Gatsby from data nodes.
+ *
+ * [Gatsby Node API]{@link https://www.gatsbyjs.org/docs/node-apis/#setFieldsOnGraphQLNodeType}
+ *
+ * @param {Object} type An object containing the type `name` and `nodes`
+ */
+exports.setFieldsOnGraphQLNodeType = ({ type }) => {
+  const { name, nodes } = type
   if (name === "ParliamentNavigation") {
-    return nodes
-      .map(({ id, parent, children, internal, ...rest }) => Object.keys(rest))
-      .reduce((a, f) => a.concat(f), [])
-      .reduce((o, name) => ({ ...o, [name]: GraphQLJSON }), {})
+    console.log(JSON.stringify(nodes))
+    return reduceGraphQLToJson(nodes)
   }
 }
 

--- a/plugins/navigation-files-transformer/gatsby-node.js
+++ b/plugins/navigation-files-transformer/gatsby-node.js
@@ -1,3 +1,15 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
 const fromJson = require("./src/fromJson")
 const fromYaml = require("./src/fromYaml")
 const reduceGraphQLToJson = require("./src/utils")

--- a/plugins/navigation-files-transformer/src/__tests__/__snapshots__/utiils.test.js.snap
+++ b/plugins/navigation-files-transformer/src/__tests__/__snapshots__/utiils.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Magento devdocs navigation format 1`] = `
+Object {
+  "homePage": "JSON",
+  "order": "JSON",
+  "pages": "JSON",
+  "section": "JSON",
+  "title": "JSON",
+}
+`;
+
+exports[`manifest-docs.json format 1`] = `
+Object {
+  "homePage": "JSON",
+  "order": "JSON",
+  "pages": "JSON",
+  "section": "JSON",
+  "title": "JSON",
+}
+`;

--- a/plugins/navigation-files-transformer/src/__tests__/fromJson.test.js
+++ b/plugins/navigation-files-transformer/src/__tests__/fromJson.test.js
@@ -1,3 +1,15 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
 const fromJson = require("../fromJson")
 
 test("manifest-docs.json content", () => {
@@ -87,7 +99,7 @@ test("Valid json but not a navigation file", () => {
     "name": "Yaml file",
     "id": "112358",
     "message": "Hello World"
-}    
+}
 `
   const parsedContent = fromJson(fileContent)
 

--- a/plugins/navigation-files-transformer/src/__tests__/fromYaml.test.js
+++ b/plugins/navigation-files-transformer/src/__tests__/fromYaml.test.js
@@ -1,3 +1,15 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
 const fromYaml = require("../fromYaml")
 
 test("Magento devdocs navigation format", () => {

--- a/plugins/navigation-files-transformer/src/__tests__/utiils.test.js
+++ b/plugins/navigation-files-transformer/src/__tests__/utiils.test.js
@@ -1,0 +1,188 @@
+const reduceGraphQLToJson = require("../utils")
+
+test("Magento devdocs navigation format", () => {
+  const nodes = [
+    {
+      section: "section-1",
+      title: "About",
+      homePage: "/",
+      order: 1,
+      pages: [
+        { title: "Home", path: "/", pages: [] },
+        {
+          title: "Page 2",
+          path: "/page-2/",
+          pages: [
+            {
+              title: "Example",
+              path: "/example/",
+              pages: [
+                { title: "Nest a page", path: "/nested/page/", pages: [] },
+              ],
+            },
+          ],
+        },
+        { title: "Diagrams", path: "/diagrams/", pages: [] },
+        { title: "Hello World", path: "/hello/", pages: [] },
+      ],
+      id: "e5d5a1de-9d87-5aa5-9726-1ae4174014c6",
+      children: [],
+      parent: "de4432b9-f901-580c-8541-f3c966b63d3d",
+      internal: {
+        content: "",
+        contentDigest: "f6d5d4facb217c8ef592b70110f87f11",
+        type: "ParliamentNavigation",
+        counter: 189,
+        owner: "navigation-files-transformer",
+      },
+    },
+  ]
+
+  expect(reduceGraphQLToJson(nodes)).toMatchSnapshot()
+})
+
+test("manifest-docs.json format", () => {
+  const nodes = [
+    {
+      section: "Analytics",
+      title: "Analytics",
+      order: 0,
+      pages: [
+        {
+          title: "Overview",
+          path: "DevRel/analytics-2.0-apis/master/README.md",
+          pages: [],
+        },
+        {
+          title: "Include Inline",
+          path: "DevRel/analytics-2.0-apis/master/wrap-support.md",
+          pages: [],
+        },
+        {
+          title: "SDS",
+          path: "",
+          pages: [
+            {
+              title: "JSON File",
+              path: "DevRel/analytics-2.0-apis/master/SDS/swagger.json",
+              pages: [],
+            },
+            {
+              title: "Markdown File",
+              path: "DevRel/analytics-2.0-apis/master/SDS/swagger.md",
+              pages: [],
+            },
+          ],
+        },
+        {
+          title: "API References",
+          path: "",
+          pages: [
+            {
+              title: "Analytics APIs",
+              path: "DevRel/analytics-2.0-apis/master/docs/swagger.json",
+              pages: [],
+            },
+            {
+              title: "Petstore APIs",
+              path: "DevRel/analytics-2.0-apis/master/docs/petstore.yaml",
+              pages: [],
+            },
+          ],
+        },
+        {
+          title: "Getting Started",
+          path: "DevRel/analytics-2.0-apis/master/create-oauth-client.md",
+          pages: [
+            {
+              title: "Creating an OAuth Client",
+              path: "DevRel/analytics-2.0-apis/master/create-oauth-client.md",
+              pages: [],
+            },
+            {
+              title: "OAuth using cURL",
+              path: "DevRel/analytics-2.0-apis/master/oauth-curl.md",
+              pages: [],
+            },
+            {
+              title: "OAuth using POSTMAN",
+              path: "DevRel/analytics-2.0-apis/master/oauth-postman.md",
+              pages: [],
+            },
+            {
+              title: "JWT Authentication",
+              path: "DevRel/analytics-2.0-apis/master/jwt.md",
+              pages: [],
+            },
+          ],
+        },
+        {
+          title: "Reporting API Guide",
+          path: "DevRel/analytics-2.0-apis/master/reporting-guide.md",
+          pages: [
+            {
+              title: "Reporting with Multiple Breakdowns",
+              path:
+                "DevRel/analytics-2.0-apis/master/reporting-multiple-breakdowns.md",
+              pages: [],
+            },
+            {
+              title: "Reporting Tips and Tricks",
+              path: "DevRel/analytics-2.0-apis/master/reporting-tricks.md",
+              pages: [],
+            },
+          ],
+        },
+        {
+          title: "Migrating Guide",
+          path: "DevRel/analytics-2.0-apis/master/migration-guide.md",
+          pages: [],
+        },
+        {
+          title: "Calculated Metrics",
+          path: "DevRel/analytics-2.0-apis/master/calculatedmetrics.md",
+          pages: [],
+        },
+        {
+          title: "Segments APIs",
+          path: "DevRel/analytics-2.0-apis/master/segments-guide.md",
+          pages: [
+            {
+              title: "Segment Definition Data Structure",
+              path: "DevRel/analytics-2.0-apis/master/segments.md",
+              pages: [],
+            },
+          ],
+        },
+        {
+          title: "FAQ",
+          path: "DevRel/analytics-2.0-apis/master/faq.md",
+          pages: [],
+        },
+        {
+          title: "Support",
+          path: "DevRel/analytics-2.0-apis/master/support.md",
+          pages: [],
+        },
+        {
+          title: "YouTube",
+          path: "DevRel/analytics-2.0-apis/master/youtube.md",
+          pages: [],
+        },
+      ],
+      homePage: "DevRel/analytics-2.0-apis/master/README.md",
+      id: "5d67cc28-602c-5ebb-8307-c1d81240d893",
+      children: [],
+      parent: "75819261-56f3-5484-91e1-d4851a641d4b",
+      internal: {
+        content: "",
+        contentDigest: "b778acbd958c405167b1936d1f95369e",
+        type: "ParliamentNavigation",
+        counter: 192,
+        owner: "navigation-files-transformer",
+      },
+    },
+  ]
+
+  expect(reduceGraphQLToJson(nodes)).toMatchSnapshot()
+})

--- a/plugins/navigation-files-transformer/src/__tests__/utiils.test.js
+++ b/plugins/navigation-files-transformer/src/__tests__/utiils.test.js
@@ -1,3 +1,15 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
 const reduceGraphQLToJson = require("../utils")
 
 test("Magento devdocs navigation format", () => {

--- a/plugins/navigation-files-transformer/src/fromJson.js
+++ b/plugins/navigation-files-transformer/src/fromJson.js
@@ -1,4 +1,16 @@
 /**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+/**
  * Converts an array of manifest-docs.json page objects into a standard
  * format for a parliamentNavigation GraphQL node object.
  *

--- a/plugins/navigation-files-transformer/src/fromYaml.js
+++ b/plugins/navigation-files-transformer/src/fromYaml.js
@@ -1,3 +1,15 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
 const yamlParser = require("yaml")
 
 /**

--- a/plugins/navigation-files-transformer/src/utils.js
+++ b/plugins/navigation-files-transformer/src/utils.js
@@ -1,3 +1,15 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
 const { GraphQLJSON } = require("gatsby/graphql")
 
 const reduceGraphQLToJson = nodes => {

--- a/plugins/navigation-files-transformer/src/utils.js
+++ b/plugins/navigation-files-transformer/src/utils.js
@@ -1,0 +1,10 @@
+const { GraphQLJSON } = require("gatsby/graphql")
+
+const reduceGraphQLToJson = nodes => {
+  return nodes
+    .map(({ id, parent, children, internal, ...rest }) => Object.keys(rest))
+    .reduce((a, f) => a.concat(f), [])
+    .reduce((o, name) => ({ ...o, [name]: GraphQLJSON }), {})
+}
+
+module.exports = reduceGraphQLToJson

--- a/src/templates/indexTemplate.js
+++ b/src/templates/indexTemplate.js
@@ -12,8 +12,17 @@
 
 import { useEffect } from "react"
 import { navigate } from "gatsby"
+// import { stripManifestPath } from "@adobe/parliament-ui-components"
 
 const IndexTemplate = props => {
+  /*
+  const homePage = stripManifestPath(props.data.parliamentNavigation.homePage, {
+    org: props.pageContext.gitRemote.organization,
+    name: props.pageContext.gitRemote.name,
+    branch: props.pageContext.gitRemote.ref,
+  })
+  */
+
   useEffect(() => {
     navigate(props.pageContext.redirect, {
       replace: true,
@@ -21,5 +30,15 @@ const IndexTemplate = props => {
   })
   return null
 }
+
+/*
+export const query = graphql`
+  query HomePageQuery {
+    parliamentNavigation {
+      homePage
+    }
+  }
+`
+*/
 
 export default IndexTemplate

--- a/src/templates/indexTemplate.js
+++ b/src/templates/indexTemplate.js
@@ -11,27 +11,23 @@
  */
 
 import { useEffect } from "react"
-import { navigate } from "gatsby"
-// import { stripManifestPath } from "@adobe/parliament-ui-components"
+import { graphql, navigate } from "gatsby"
+import { stripManifestPath } from "@adobe/parliament-ui-components"
 
 const IndexTemplate = props => {
-  /*
-  const homePage = stripManifestPath(props.data.parliamentNavigation.homePage, {
-    org: props.pageContext.gitRemote.organization,
-    name: props.pageContext.gitRemote.name,
-    branch: props.pageContext.gitRemote.ref,
-  })
-  */
+  const homePage = stripManifestPath(
+    props.data.parliamentNavigation.homePage,
+    props.pageContext.gitRemote
+  )
 
   useEffect(() => {
-    navigate(props.pageContext.redirect, {
+    navigate(homePage, {
       replace: true,
     })
   })
   return null
 }
 
-/*
 export const query = graphql`
   query HomePageQuery {
     parliamentNavigation {
@@ -39,6 +35,5 @@ export const query = graphql`
     }
   }
 `
-*/
 
 export default IndexTemplate

--- a/src/templates/markdownTemplate.js
+++ b/src/templates/markdownTemplate.js
@@ -29,22 +29,21 @@ import {
   ActionButtons,
 } from "@adobe/parliament-ui-components"
 
-const MarkdownTemplate = props => {
-  const { file } = props.data
+const MarkdownTemplate = ({ data, location, pageContext }) => {
+  const { file, parliamentNavigation } = data
   const { modifiedTime, relativePath, childMarkdownRemark } = file
   const { htmlAst, tableOfContents, timeToRead } = childMarkdownRemark
-
-  const { gitRemote, pages } = props.pageContext
+  const { gitRemote } = pageContext
 
   return (
     <DocLayout>
-      <SEO title={props.pageContext.seo} />
+      <SEO title={pageContext.seo} />
       <Grid>
         <GridNav>
           <SiteNav
-            currentPage={props.location.pathname}
+            currentPage={location.pathname}
             gitRemote={gitRemote}
-            pages={pages}
+            pages={parliamentNavigation.pages}
           />
         </GridNav>
         <GridContent id="contentMain">
@@ -123,6 +122,9 @@ export const query = graphql`
         tableOfContents
         timeToRead
       }
+    }
+    parliamentNavigation {
+      pages
     }
   }
 `

--- a/src/templates/openapiTemplate.js
+++ b/src/templates/openapiTemplate.js
@@ -26,7 +26,8 @@ import {
   OpenApiGridFooter,
 } from "@adobe/parliament-ui-components"
 
-const OpenApiTemplate = ({ pageContext, location }) => {
+const OpenApiTemplate = ({ data, pageContext, location }) => {
+  const { parliamentNavigation } = data
   return (
     <DocLayout>
       <SEO title={pageContext.seo} />
@@ -36,7 +37,7 @@ const OpenApiTemplate = ({ pageContext, location }) => {
             currentPage={location.pathname}
             gitRemote={pageContext.gitRemote}
             forceMobile={true}
-            pages={pageContext.pages}
+            pages={parliamentNavigation.pages}
           />
         </OpenApiGridNav>
         <OpenApiGridContent>
@@ -55,5 +56,13 @@ const OpenApiTemplate = ({ pageContext, location }) => {
     </DocLayout>
   )
 }
+
+export const query = graphql`
+  query OpenApiTemplateQuery {
+    parliamentNavigation {
+      pages
+    }
+  }
+`
 
 export default OpenApiTemplate

--- a/src/templates/recipeTemplate.js
+++ b/src/templates/recipeTemplate.js
@@ -28,22 +28,22 @@ import {
   GridFooter,
 } from "@adobe/parliament-ui-components"
 
-const MarkdownTemplate = props => {
-  const { file } = props.data
+const MarkdownTemplate = ({ data, location, pageContext }) => {
+  const { file } = data
   const { childMarkdownRemark } = file
   const { htmlAst } = childMarkdownRemark
 
-  const { gitRemote, pages } = props.pageContext
+  const { gitRemote } = pageContext
 
   return (
     <DocLayout>
-      <SEO title={props.pageContext.seo} />
+      <SEO title={pageContext.seo} />
       <Grid>
         <GridNav>
           <SiteNav
-            currentPage={props.location.pathname}
+            currentPage={location.pathname}
             gitRemote={gitRemote}
-            pages={pages}
+            pages={pageContext.pages}
           />
         </GridNav>
         <GridContent>
@@ -67,6 +67,9 @@ export const query = graphql`
       childMarkdownRemark {
         htmlAst
       }
+    }
+    parliamentNavigation {
+      pages
     }
   }
 `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The side nav data is put in the DB by the `navigation-transformer-files` plugin. We are now reading the side nav content from the graphql DB in our page templates. Also cleared out a lot of code we don't need in gatsby-node.js anymore.

## Related Issue

n/a

## Motivation and Context

This sets us up to support multiple data formats for side nav. `navigation-transformer-files` can read the manifest from a JSON or YAML file but then it doesn't matter to the page templates as they get the info out of the DB. Makes life way easier.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
