### PR TITLE
Updated site font to adobe-clean

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -19,7 +19,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta, title }) {
@@ -80,7 +80,9 @@ function SEO({ description, lang, meta, title }) {
           content: metaDescription,
         },
       ].concat(meta)}
-    ></Helmet>
+    >
+      <link rel="stylesheet" href="https://use.typekit.net/uma8ayv.css" />
+    </Helmet>
   )
 }
 

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -19,7 +19,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import { Helmet } from "react-helmet"
+import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta, title }) {
@@ -81,7 +81,7 @@ function SEO({ description, lang, meta, title }) {
         },
       ].concat(meta)}
     >
-      <link rel="stylesheet" href="https://use.typekit.net/uma8ayv.css" />
+      {/* <link rel="stylesheet" href="https://use.typekit.net/uma8ayv.css" /> */}
     </Helmet>
   )
 }

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -81,7 +81,7 @@ function SEO({ description, lang, meta, title }) {
         },
       ].concat(meta)}
     >
-      {/* <link rel="stylesheet" href="https://use.typekit.net/uma8ayv.css" /> */}
+      <link rel="stylesheet" href="https://use.typekit.net/uma8ayv.css" />
     </Helmet>
   )
 }


### PR DESCRIPTION
## Description

This PR adds the adobe-clean fonts per design using a typekit link. Not sure if that's the proper method for using fonts for the site. If not, let me know and I'll modify it.

## Related Issue

[Issue 12:](https://github.com/adobe/parliament-client-template/issues/12) Parliament is not using Adobe Clean font by default

## Motivation and Context

Adhering to typography/Adobe brand of fonts. And I was tired of seeing the light-weight Source Sans font that my system was determined to use. :)

## How Has This Been Tested?

I used a local clone of the analytics-2.0-apis repo.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1828494/89714161-656ebd00-d962-11ea-92bd-74c276846ccc.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
