### PR TITLE
🚀 Upgrading to latest version of redoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-helmet": "^5.2.1",
     "react-responsive": "^8.0.3",
     "rebass": "^4.0.5",
-    "redoc": "2.0.0-rc.12",
+    "redoc": "^2.0.0-rc.40",
     "rehype-react": "^4.0.1",
     "rimraf": "^3.0.2",
     "styled-components": "^4.3.2",


### PR DESCRIPTION
Earlier, Redoc version 2.0.0-rc.12 was only supported in Gatsby refer https://github.com/gatsbyjs/gatsby/issues/17136
which was causing a scrolling issue in the openApi reference page in Google chrome. 

The issues are fixed and now we can upgrade to the latest version of redoc 2.0.0-rc.40, I am able to test out locally and it is working as expected.

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/gatsbyjs/gatsby/issues/17136

## Motivation and Context

Earlier, Redoc version 2.0.0-rc.12 was only supported in Gatsby refer https://github.com/gatsbyjs/gatsby/issues/17136
which was causing a scrolling issue in the openApi reference page in Google chrome. 

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
