### PR TITLE
🐛  Determine git api url based on GATSBY_SOURCE

### DIFF
--- a/configs/development.js
+++ b/configs/development.js
@@ -7,6 +7,10 @@ require("dotenv").config({
 
 const projectRootDir = path.dirname(__dirname)
 const gitInfo = GitUrlParse(process.env.GATSBY_SOURCE)
+const apiUrl =
+  gitInfo.source === `github.com`
+    ? `https://api.github.com/graphql`
+    : `https://git.corp.adobe.com/api/graphql`
 
 module.exports = {
   plugins: [
@@ -46,7 +50,7 @@ module.exports = {
           owner: gitInfo.owner,
           name: gitInfo.name,
           branch: process.env.GATSBY_SOURCE_BRANCH,
-          api: "https://git.corp.adobe.com/api/graphql",
+          api: apiUrl,
         },
       },
     },

--- a/configs/production.js
+++ b/configs/production.js
@@ -6,6 +6,10 @@ require("dotenv").config({
 })
 
 const gitInfo = GitUrlParse(process.env.GATSBY_SOURCE)
+const apiUrl =
+  gitInfo.source === `github.com`
+    ? `https://api.github.com/graphql`
+    : `https://git.corp.adobe.com/api/graphql`
 const patterns = process.env.GATSBY_SOURCE_PATTERNS.replace(/ /g, "").split(",")
 
 const contentSourcePath = path.resolve(
@@ -47,7 +51,7 @@ module.exports = {
           owner: gitInfo.owner,
           name: gitInfo.name,
           branch: process.env.GATSBY_SOURCE_BRANCH,
-          api: "https://git.corp.adobe.com/api/graphql",
+          api: apiUrl,
         },
       },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Depending on if we are building from github or git.corp set the API url corrrectly

## Related Issue

DEVEP-2331

## Motivation and Context

We were hardcoding to git.corp and that means github repos would fail to build.

## How Has This Been Tested?

Running gatsby develop and build

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
