### PR TITLE
Markdown cleaner plugin for smooth MDX processing: Take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,13 @@
     "react-responsive": "^8.2.0",
     "rebass": "^4.0.5",
     "rehype-react": "^6.1.0",
+    "remark-parse": "^9.0.0",
     "remark-slug": "^6.0.0",
+    "remark-stringify": "^9.0.1",
+    "shelljs": "^0.8.4",
     "styled-components": "^5.2.0",
+    "to-vfile": "^6.1.0",
+    "unified": "^9.2.0",
     "widdershins": "^4.0.1",
     "yaml": "^1.7.2"
   },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gatsby-transformer-yaml-full": "^0.3.4",
     "git-url-parse": "^11.1.2",
     "graphql-type-json": "^0.3.2",
+    "html-tags": "^3.1.0",
     "mobx": "^4.2.0",
     "node-fetch": "^2.6.1",
     "openapi-snippet": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "build": "gatsby build",
     "build:prod": "gatsby build --prefix-paths",
     "clean": "gatsby clean",
+    "cleanmarkdown": "NODE_ENV=development node ./scripts/markdown-cleaner/index.js",
+    "cleanmarkdown:prod": "NODE_ENV=production node ./scripts/markdown-cleaner/index.js",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public -r git@github.com:adobe/parliament-client-template.git",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",

--- a/scripts/markdown-cleaner/addLineBreaks.js
+++ b/scripts/markdown-cleaner/addLineBreaks.js
@@ -1,0 +1,75 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+module.exports = addLineBreaks
+
+/**
+ * Adds an empty line (carriage return) to most HTML/JSX tags/components in the markdown file.
+ * This ensures the tag or component is processed correctly as JSX. Otherwise content that
+ * immediately follows the tag/component will be concatenated and processed as plain text.
+ * See https://github.com/adobe/gatsby-theme-parliament/issues/19#issuecomment-699075713.
+ *
+ * @param {string} nodeValue  The node value from the MDAST tree (file) being processed.
+ */
+function addLineBreaks(nodeValue) {
+  const hasPreTags = nodeValue.includes("<pre>") || nodeValue.includes("</pre>")
+  const hasTableTags =
+    nodeValue.includes("<table>") || nodeValue.includes("</table>")
+  const hasParagraphTags =
+    nodeValue.includes("<p>") || nodeValue.includes("</p>")
+  const openImage = nodeValue.match(/<img\s*(.*?)([^\/])[^](?<=\"|\"\s+)>/g)
+
+  // If paragraph tags (`<p></p>`) are not removed first, they can hide,
+  // the 'bad tags' that will break the build during MDX/JSX processing.
+  //
+  if (hasParagraphTags) {
+    replaceTag(nodeValue.match(/\<p\s*(.*?)\>/g), "")
+    replaceTag(nodeValue.match(/\<\/p\>/g), "\n\r")
+    return nodeValue
+  }
+
+  // Close open img tags
+  if (openImage) {
+    replaceTag(openImage, openImage[0].split(">").join("/>"))
+  }
+
+  // If there are HTML tables in the markdown, don't add line breaks,
+  // but replace any <br> tags within those tables. This could be expanded.
+  //
+  if (hasTableTags) {
+    replaceTag(nodeValue.match(/\<br\>/g), "<br/>")
+    return nodeValue
+  }
+
+  // If there are HTML <pre> tags demarcating code in the markdown,
+  // don't add line breaks. Just replace the <pre> tags with markdown
+  // code blocks and a dummy value for the language that can be searched
+  // for and replaced by the content maintainer.
+  //
+  if (hasPreTags) {
+    replaceTag(nodeValue.match(/\<pre\>/g), "```add_language")
+    replaceTag(nodeValue.match(/\<\/pre\>/g), "```\n\r")
+    return nodeValue
+  }
+
+  // adds critical line break (carriage return) to all other tags
+  const tagNoLine = nodeValue.match(/(?<=(>))\s*\n/g)
+  replaceTag(tagNoLine, "\n\r")
+  return nodeValue
+
+  function replaceTag(invalidTag, replacement) {
+    if (invalidTag) {
+      let fixedTag = invalidTag[0].split(invalidTag[0]).join(replacement)
+      nodeValue = nodeValue.split(invalidTag[0]).join(fixedTag)
+    }
+  }
+}

--- a/scripts/markdown-cleaner/cleanHtmlNodes.js
+++ b/scripts/markdown-cleaner/cleanHtmlNodes.js
@@ -70,8 +70,8 @@ function cleanHtmlNodes(nodeValue, pluginOptionTags) {
 
   function isValidHtmlTag(tag) {
     const pattern = /<\/?(\w+)[^>]*>/
-    const data = tag.match(pattern)[1]
-    return parliamentTags.includes(data)
+    const matches = tag.match(pattern)
+    return matches ? parliamentTags.includes(matches[1]) : false
   }
 
   if (!isValidHtmlTag(nodeValue)) {

--- a/scripts/markdown-cleaner/cleanHtmlNodes.js
+++ b/scripts/markdown-cleaner/cleanHtmlNodes.js
@@ -9,6 +9,8 @@
  *  OF ANY KIND, either express or implied. See the License for the specific language
  *  governing permissions and limitations under the License.
  */
+const htmlTags = require("html-tags")
+const parliamentTags = ["newtonbutton", ...htmlTags]
 
 module.exports = cleanHtmlNodes
 
@@ -64,6 +66,16 @@ function cleanHtmlNodes(nodeValue, pluginOptionTags) {
       let fixedTag = invalidTag[0].split(invalidTag[0]).join(replacement)
       nodeValue = nodeValue.split(invalidTag[0]).join(fixedTag)
     }
+  }
+
+  function isValidHtmlTag(tag) {
+    const pattern = /<\/?(\w+)[^>]*>/
+    const data = tag.match(pattern)[1]
+    return parliamentTags.includes(data)
+  }
+
+  if (!isValidHtmlTag(nodeValue)) {
+    nodeValue = nodeValue.replace(/</g, "&lt;").replace(/>/g, "&gt;")
   }
 
   return nodeValue

--- a/scripts/markdown-cleaner/cleanHtmlNodes.js
+++ b/scripts/markdown-cleaner/cleanHtmlNodes.js
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+module.exports = cleanHtmlNodes
+
+function cleanHtmlNodes(nodeValue, pluginOptionTags) {
+  const optionalHtmlTags = {
+    "<em>": () => {
+      replaceTag(nodeValue.match(/(<em>+|<\/em>)/g), "_")
+    },
+    "<strong>": () => {
+      replaceTag(nodeValue.match(/(<strong>+|<\/strong>)/g), "**")
+    },
+    "<i>": () => {
+      replaceTag(nodeValue.match(/(<i>+|<\/i>)/g), "_")
+    },
+    "<s>": () => {
+      replaceTag(nodeValue.match(/(<s>+|<\/s>)/g), "~~")
+    },
+    default: () => {
+      console.log(`The ${tag} tag is not yet supported.`)
+    },
+  }
+
+  const breakingHtmlTags = {
+    "<hr>": () => {
+      replaceTag(nodeValue.match(/<hr>/g), "<hr/>")
+    },
+    "<br>": () => {
+      replaceTag(nodeValue.match(/<br>/g), "<br/>")
+    },
+    "<b>": () => {
+      replaceTag(nodeValue.match(/(<b>)/g), "**")
+    },
+    "</b>": () => {
+      replaceTag(nodeValue.match(/(<\/b>)/g), "**")
+    },
+    "<wbr>": () => {
+      replaceTag(nodeValue.match(/<wbr>/g), "")
+    },
+    "<pre/>": () => {
+      replaceTag(nodeValue.match(/<pre\/>/g), "")
+    },
+    default: () => {
+      for (tag of pluginOptionTags) {
+        ;(optionalHtmlTags[tag] || optionalHtmlTags["default"])()
+      }
+    },
+  }
+
+  ;(breakingHtmlTags[nodeValue] || breakingHtmlTags["default"])()
+
+  function replaceTag(invalidTag, replacement) {
+    if (invalidTag) {
+      let fixedTag = invalidTag[0].split(invalidTag[0]).join(replacement)
+      nodeValue = nodeValue.split(invalidTag[0]).join(fixedTag)
+    }
+  }
+
+  return nodeValue
+}

--- a/scripts/markdown-cleaner/index.js
+++ b/scripts/markdown-cleaner/index.js
@@ -1,0 +1,63 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+const unified = require("unified")
+const parse = require("remark-parse")
+const stringify = require("remark-stringify")
+const vfile = require("to-vfile")
+const shell = require("shelljs")
+const markdownCleaner = require("./markdownCleaner")
+
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
+const cleaningOptions = {
+  addLineBreaks: "addLineBreaks",
+  cleanHtmlNodes: "cleanHtmlNodes",
+}
+
+const optionalTags = []
+
+const files = shell.ls("-RLl", `${process.env.LOCAL_PROJECT_DIRECTORY}/**/*.md`)
+
+for (const file of files) {
+  if (file.isFile()) {
+    // Adds proper line breaks below HTML/JSX tags so they can be processed correctly
+    unified()
+      .use(parse)
+      .use(markdownCleaner, cleaningOptions.addLineBreaks)
+      .use(stringify)
+      .process(vfile.readSync(`${file.name}`), function (err, file) {
+        if (err) {
+          console.error(err)
+        }
+        if (file) {
+          vfile.writeSync(file)
+        }
+      })
+
+    // Fixes HTML/JSX tags by transforming HTML into markdown or adding closing tags as needed.
+    unified()
+      .use(parse)
+      .use(markdownCleaner, cleaningOptions.cleanHtmlNodes, optionalTags)
+      .use(stringify)
+      .process(vfile.readSync(`${file.name}`), function (err, file) {
+        if (err) {
+          console.error(err)
+        }
+        if (file) {
+          vfile.writeSync(file)
+        }
+      })
+  }
+}

--- a/scripts/markdown-cleaner/markdownCleaner.js
+++ b/scripts/markdown-cleaner/markdownCleaner.js
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+const addLineBreaks = require("./addLineBreaks")
+const cleanHtmlNodes = require("./cleanHtmlNodes")
+
+module.exports = markdownCleaner
+
+function markdownCleaner(cleaningOption, pluginOptionTags = []) {
+  return cleanMarkdown
+  function cleanMarkdown(node) {
+    const type = node && node.type
+    if (type === `html`) {
+      let nodeValue
+      if (cleaningOption === "addLineBreaks") {
+        nodeValue = addLineBreaks(node.value)
+      } else {
+        nodeValue = cleanHtmlNodes(node.value, pluginOptionTags)
+      }
+      try {
+        node.value = nodeValue
+      } catch (e) {
+        throw Error(`${e.message}`)
+      }
+    }
+    if (node.children) {
+      let nodes = []
+      for (const childNode of node.children) {
+        let cleanedNode = cleanMarkdown(childNode)
+        nodes.push(cleanedNode)
+      }
+      node.children = nodes
+    }
+    return node
+  }
+}

--- a/scripts/markdown-cleaner/markdownCleaner.js
+++ b/scripts/markdown-cleaner/markdownCleaner.js
@@ -31,6 +31,15 @@ function markdownCleaner(cleaningOption, pluginOptionTags = []) {
       } catch (e) {
         throw Error(`${e.message}`)
       }
+    } else {
+      // if the node is not html convert < and > to &lt; and &gt;
+      if (node.value) {
+        try {
+          node.value = node.value.replace(/</g, "&lt;").replace(/>/g, "&gt;")
+        } catch (e) {
+          throw Error(`${e.message}`)
+        }
+      }
     }
     if (node.children) {
       let nodes = []

--- a/src/components/componentsMapping.js
+++ b/src/components/componentsMapping.js
@@ -32,6 +32,7 @@ import {
 } from "@adobe/parliament-ui-components"
 import NewtonButton from "./NewtonButton"
 
+// If you add a new custom tag here be sure to add it to scripts/markdown-cleaner/cleanHtmlNodes.js as well
 export const componentsMapping = {
   alert: Alert,
   h1: Heading1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7178,7 +7178,7 @@ debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, de
   dependencies:
     ms "2.0.0"
 
-debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4.3.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -10044,7 +10044,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -11206,6 +11206,11 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 intl-messageformat-parser@1.4.0:
   version "1.4.0"
@@ -12976,7 +12981,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-longest-streak@^2.0.1:
+longest-streak@^2.0.0, longest-streak@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
@@ -13250,6 +13255,17 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.4.tgz#2882100c1b9fc967d3f83806802f303666682d32"
+  integrity sha512-jj891B5pV2r63n2kBTFh8cRI2uR9LQHsXG1zSDqfhXkIlDzrTcIlbB5+5aaYEkl8vOPIOPLf8VT7Ere1wWTMdw==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz#0cfc82089494c52d46eb0e3edb7a4eb2aea021eb"
@@ -13280,6 +13296,18 @@ mdast-util-to-hast@^3.0.4:
     unist-util-position "^3.0.0"
     unist-util-visit "^1.1.0"
     xtend "^4.0.1"
+
+mdast-util-to-markdown@^0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.2.tgz#8fe6f42a2683c43c5609dfb40407c095409c85b4"
+  integrity sha512-iRczns6WMvu0hUw02LXsPDJshBIwtUPbvHBWo19IQeU0YqmzlA8Pd30U8V7uiI0VPkxzS7A/NXBXH6u+HS87Zg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    longest-streak "^2.0.0"
+    mdast-util-to-string "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    zwitch "^1.0.0"
 
 mdast-util-to-nlcst@^3.2.0:
   version "3.2.3"
@@ -13423,6 +13451,14 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromark@~2.11.0:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.2.tgz#e8b6a05f54697d2d3d27fc89600c6bc40dd05f35"
+  integrity sha512-IXuP76p2uj8uMg4FQc1cRE7lPCLsfAXuEfdjtdO55VRiFO1asrCSQ5g43NmPqFtRwzEnEhafRVzn2jg0UiKArQ==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -16168,6 +16204,13 @@ rebass@^4.0.5:
   dependencies:
     reflexbox "^4.0.6"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 recursive-readdir@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
@@ -16435,6 +16478,13 @@ remark-parse@^6.0.0, remark-parse@^6.0.3:
     vfile-location "^2.0.0"
     xtend "^4.0.1"
 
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
+  dependencies:
+    mdast-util-from-markdown "^0.8.0"
+
 remark-retext@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/remark-retext/-/remark-retext-3.1.3.tgz#77173b1d9d13dab15ce5b38d996195fea522ee7f"
@@ -16497,6 +16547,13 @@ remark-stringify@^8.1.0:
     stringify-entities "^3.0.0"
     unherit "^1.0.4"
     xtend "^4.0.1"
+
+remark-stringify@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
+  integrity sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
 
 remark@^10.0.1:
   version "10.0.1"
@@ -16669,7 +16726,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
@@ -17150,6 +17207,15 @@ shell-quote@1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -18479,6 +18545,14 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+to-vfile@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-6.1.0.tgz#5f7a3f65813c2c4e34ee1f7643a5646344627699"
+  integrity sha512-BxX8EkCxOAZe+D/ToHdDsJcVI4HqQfmw0tCkp31zf3dNP/XWIAjU4CmeuSwsSoOzOTqHPOL0KUzyZqJplkD0Qw==
+  dependencies:
+    is-buffer "^2.0.0"
+    vfile "^4.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -18745,7 +18819,7 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
 
-unified@9.2.0, unified@^9.1.0:
+unified@9.2.0, unified@^9.1.0, unified@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.0.tgz#67a62c627c40589edebbf60f53edfd4d822027f8"
   integrity sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10765,6 +10765,11 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-tags@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
+  integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
+
 html-void-elements@^1.0.0, html-void-elements@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a script that formats and fixes HTML tags that break the MDX/JSX processing of markdown files. Existing markdown files often contain HTML tags. And some of these HTML tags break the build when the new MDX markdown processor (used in gatsby-theme-parliament and parliament-client-template) tries to parse them.

This plugin fixes those HTML tags by either converting them to proper CommonMark markdown or closing the tags so that they are interpreted as valid JSX by the MDX parser.


## Related Issues

- https://github.com/adobe/gatsby-theme-parliament/issues/25
- https://github.com/adobe/gatsby-theme-parliament/issues/19

## Motivation and Context

Markdown should be as pure as possible, without HTML tags that will cause issues in building and displaying markdown content. Using MDX as a superset of CommonMark opens up a world of interactive documentation using markdown. This plugin helps smooth the transition between CommonMark and CommonMark with JSX, otherwise known as MDX. 

## How Has This Been Tested?

I used the sample `analytics-2.0-apis` docs with these two markdown files (among others):
- [README.txt](https://github.com/adobe/parliament-client-template/files/5405694/README.txt) (save with `.md` extension)
- [test2.txt](https://github.com/adobe/parliament-client-template/files/5405687/test2.txt) (save with `.md` extension)

**Sample of `README.md` can be found here:**

```
This is not the official Adobe analytics API <b>documentation</b>, please refer to <https://github.com/AdobeDocs/analytics-2.0-apis>
<br>
<hr>
<img src="./docs/adobe_icon.png">
<img src="./docs/adobe_icon.png">
This text is <i>italic</i> and this is not. <em>Now</em>.
<span> <em>Emphasis</em> <strong>Strong</strong> </span>

<pre>
{
  function myFunction() {
    // do something
  }
}
</pre>
<pre>
{
  <div class="test">This is my div tag.</div>
}
</pre>
```json
{
  "Key": "Value"
}
```

Markdown tables with `<br>` tags:
```
| Open Tag  | Description                   | Valid Tag Replacement |
|-----------|-------------------------------|-----------------------|
| `<br>`    | Break                         | `<br/>`               |
| `<hr>`    | Horizontal line               | `<hr/>`               |
| Just text | Text with <br> and more text. | More text with <br>   |

This is a sentence that uses <code>a `<code>` code snippet</code> in the middle.

<iframe src="" width="100%" height="100" style="border:none;">
</iframe>
```

HTML code blocks:
```html
<div>My div tag</div>
```

HTML lists with `<b>` tags:
```
<ol>
  <li>Coffee and <b>Coke</b> </li>
  <li>Tea</li>
  <li>Milk</li>
</ol>

<ul>
  <li>Coffee</li>
  <li>Tea</li>
  <li>Milk</li>
</ul>
```

HTML tables with `<br>` tags:
```
<table style="width:100%">
<tr>
    <th>Firstname with a <br> tag in there.</th>
    <th>Lastname</th>
    <th>Age</th>
  </tr>
  <tr>
    <td><b>Jill</b></td>
    <td>Smith</td>
    <td>50</td>
  </tr>
  <tr>
    <td>Eve</td>
    <td><pre>Jackson Code</pre> Jackson</td>
    <td>94</td>
  </tr>
</table>
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
