### PR TITLE
🐛 remove whitespaces from patterns

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,7 +25,9 @@ const apiUrl =
     ? `https://api.github.com/graphql`
     : `https://git.corp.adobe.com/api/graphql`
 
-const patterns = process.env.GATSBY_SOURCE_PATTERNS.replace(/ /g,'').split(",")
+const patterns = process.env.GATSBY_SOURCE_PATTERNS.split(",").map((item) =>
+  item.trim()
+)
 const ignorePatterns = patterns
   .filter((pattern) => pattern.startsWith("!"))
   .map(

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,7 +25,7 @@ const apiUrl =
     ? `https://api.github.com/graphql`
     : `https://git.corp.adobe.com/api/graphql`
 
-const patterns = process.env.GATSBY_SOURCE_PATTERNS.split(",")
+const patterns = process.env.GATSBY_SOURCE_PATTERNS.replace(/ /g,'').split(",")
 const ignorePatterns = patterns
   .filter((pattern) => pattern.startsWith("!"))
   .map(


### PR DESCRIPTION
If the pattern definition has a whitespace e.g. `**/*, !config/**` the condition `pattern.startsWith("!")` will fail since the pattern is starting with a ' ' whitespace, hence it is important to remove all whitespaces from the patterns before splitting by a comma.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
