### PR TITLE
🐛  DEVEP-2599: OpenAPI spec with empty path name fails to build

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -36,6 +36,11 @@ const openApiSearchDocs = []
 
 const pages = []
 
+const renameProp = (oldProp, newProp, { [oldProp]: old, ...others }) => ({
+  [newProp]: old,
+  ...others,
+})
+
 async function asyncForEach(array, callback) {
   for (let index = 0; index < array.length; index++) {
     await callback(array[index], index, array)
@@ -444,6 +449,9 @@ const processOpenApiFiles = async (
 
         try {
           const swaggerObject = await SwaggerParser.bundle(filepath)
+          if (Object.keys(swaggerObject.paths).includes("")) {
+            swaggerObject.paths = renameProp("", "/", swaggerObject.paths)
+          }
           await createOpenApiPage(
             createPage,
             openapiTemplate,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Detects if a swagger file will not build due to graphql limitations

## Related Issue

DEVEP-2599

## Motivation and Context

Certain swagger files will cause the build to fail. If they have an empty path key "" that is not a valid key name in graphql.

## How Has This Been Tested?

Tested locally with gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
