### PR TITLE
🐛  DEVEP-2652: Edit in Github link broken

### DIFF
--- a/src/templates/markdownTemplate.js
+++ b/src/templates/markdownTemplate.js
@@ -27,9 +27,13 @@ import {
 
 const MarkdownTemplate = ({ data, location, pageContext }) => {
   const { file, parliamentNavigation } = data
-  const { relativePath, childMdx } = file
+  const { absolutePath, childMdx } = file
   const { body, tableOfContents, timeToRead } = childMdx
   const { contributors, gitRemote } = pageContext
+  const relativePath = absolutePath.replace(
+    `${process.env.LOCAL_PROJECT_DIRECTORY}/`,
+    ""
+  )
 
   return (
     <DocLayout
@@ -111,7 +115,7 @@ export const query = graphql`
     file(id: { eq: $id }) {
       id
       name
-      relativePath
+      absolutePath
       childMdx {
         body
         tableOfContents(maxDepth: 3)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Determines the correct path to edit the file in github

## Related Issue

DEVEP-2652

## Motivation and Context

To fix the Edit in Github link

## How Has This Been Tested?

gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
