### PR TITLE
Courses, LocalStore, Nav w/ Max Depth!

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -381,6 +381,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
             path: node.fields.slug,
             component: template,
             context: {
+              dirname: path.parse(node.fields.slug).dir,
               slug: node.fields.slug,
               id: node.fields.id,
               seo: seo,

--- a/src/components/CourseNav.js
+++ b/src/components/CourseNav.js
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import React from 'react'
+import PropTypes from 'prop-types'
+import { navigate } from 'gatsby'
+import { stripManifestPath, defaultFocus } from '@adobe/parliament-ui-components'
+
+import '@spectrum-css/sidenav'
+
+const nav = (data, gitInfo, defaultFocus, currDepth, maxDepth) => {
+  if (currDepth >= maxDepth) {
+    return ''
+  }
+
+  return (
+    <ul className='spectrum-SideNav  spectrum-SideNav--multiLevel'>
+      {data.map((node, index) => {
+        const updatedPath = stripManifestPath(node.path, gitInfo)
+        const isSelected =
+          node.title === defaultFocus
+            ? 'spectrum-SideNav-item is-selected'
+            : 'spectrum-SideNav-item'
+
+        return (
+          <li className={isSelected} key={index}>
+            <a
+              href='#'
+              className='spectrum-SideNav-itemLink'
+              onClick={() => {
+                if (updatedPath) {
+                  if (
+                    updatedPath.startsWith('http://') ||
+                    updatedPath.startsWith('https://')
+                  ) {
+                    document.location.href = updatedPath
+                  } else {
+                    navigate(updatedPath)
+                  }
+                }
+              }}
+            >
+              {node.title}
+            </a>
+            {node.pages ? nav(node.pages, gitInfo, defaultFocus, currDepth + 1, maxDepth) : ''}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+const CourseNav = ({ data, selected, gitInfo, ...props }) => {
+  const maxDepth = props.depth ? props.depth : 2
+  return (
+    <nav aria-label='Side Navigation' {...props}>
+      {nav(data, gitInfo, defaultFocus(data, selected, gitInfo), 0, maxDepth)}
+    </nav>
+  )
+}
+
+CourseNav.propTypes = {
+  data: PropTypes.array,
+  selected: PropTypes.string,
+  gitInfo: PropTypes.object,
+  depth: PropTypes.number,
+}
+
+CourseNav.defaultProps = {
+  data: [],
+  selected: '',
+  gitInfo: {},
+  depth: 2,
+}
+
+export default CourseNav

--- a/src/components/NextPrev.js
+++ b/src/components/NextPrev.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react"
+import { Link as GatsbyLink } from "gatsby"
+import "@spectrum-css/typography"
+import { Link } from "@adobe/parliament-ui-components"
+import ChevronLeft from "@spectrum-icons/workflow/ChevronLeft"
+import ChevronRight from "@spectrum-icons/workflow/ChevronRight"
+
+const NextPrev = ({ nextPage, previousPage }) =>
+  nextPage || previousPage ? (
+    <div className="spectrum-Body spectrum-Body--sizeM">
+      <div
+        css={css`
+          display: flex;
+          margin-bottom: var(--spectrum-global-dimension-size-800);
+          margin-top: var(--spectrum-global-dimension-size-800);
+        `}
+      >
+        <div>
+          {previousPage && (
+            <Link isQuiet={true}>
+              <GatsbyLink to={previousPage.path} rel="prev">
+                <div
+                  css={css`
+                    display: flex;
+                    align-items: center;
+                  `}
+                >
+                  <ChevronLeft />
+                  <div
+                    css={css`
+                      margin-left: var(--spectrum-global-dimension-size-50);
+                    `}
+                  >
+                    {previousPage.title}
+                  </div>
+                </div>
+              </GatsbyLink>
+            </Link>
+          )}
+        </div>
+        <div
+          css={css`
+            margin-left: auto;
+            padding-left: var(--spectrum-global-dimension-size-200);
+          `}
+        >
+          {nextPage && (
+            <Link isQuiet={true}>
+              <GatsbyLink to={nextPage.path} rel="next">
+                <div
+                  css={css`
+                    display: flex;
+                    align-items: center;
+                  `}
+                >
+                  <div
+                    css={css`
+                      margin-right: var(--spectrum-global-dimension-size-50);
+                    `}
+                  >
+                    {nextPage.title}
+                  </div>
+                  <ChevronRight />
+                </div>
+              </GatsbyLink>
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  ) : null
+
+export default NextPrev

--- a/src/components/NextPrev.js
+++ b/src/components/NextPrev.js
@@ -18,7 +18,7 @@ import { Link } from "@adobe/parliament-ui-components"
 import ChevronLeft from "@spectrum-icons/workflow/ChevronLeft"
 import ChevronRight from "@spectrum-icons/workflow/ChevronRight"
 
-const NextPrev = ({ nextPage, previousPage }) =>
+const NextPrev = ({ nextPage, previousPage, markProgression }) =>
   nextPage || previousPage ? (
     <div className="spectrum-Body spectrum-Body--sizeM">
       <div
@@ -59,7 +59,7 @@ const NextPrev = ({ nextPage, previousPage }) =>
         >
           {nextPage && (
             <Link isQuiet={true}>
-              <GatsbyLink to={nextPage.path} rel="next">
+              <GatsbyLink to={nextPage.path} rel="next" onClick={markProgression}>
                 <div
                   css={css`
                     display: flex;

--- a/src/components/SiteMenu.js
+++ b/src/components/SiteMenu.js
@@ -20,7 +20,7 @@ import { Nav, Search } from "@adobe/parliament-ui-components"
 
 import "./sitenav.css"
 
-const SiteMenu = ({ gitRemote, currentPage, pages }) => {
+const SiteMenu = ({ gitRemote, currentPage, pages, CustomNavComponent }) => {
   const { ParliamentSearchIndex } = useStaticQuery(
     graphql`
       query {
@@ -35,6 +35,8 @@ const SiteMenu = ({ gitRemote, currentPage, pages }) => {
     name: gitRemote.name,
     branch: gitRemote.ref,
   }
+
+  const LeftNavComponent = CustomNavComponent ? CustomNavComponent : Nav
 
   return (
     <div
@@ -77,7 +79,7 @@ const SiteMenu = ({ gitRemote, currentPage, pages }) => {
           overflow-x: hidden;
         `}
       >
-        <Nav data={pages} selected={currentPage} gitInfo={gitInfo} />
+      <LeftNavComponent data={pages} selected={currentPage} gitInfo={gitInfo} />
       </div>
     </div>
   )

--- a/src/markdown-pages/do-not-delete.md
+++ b/src/markdown-pages/do-not-delete.md
@@ -7,6 +7,7 @@ author: ""
 tags: ""
 description: ""
 slug: ""
+courseVersion: ""
 ---
 
 # Don't Delete:

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -1,0 +1,185 @@
+/**
+ *  Copyright 2020 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react"
+import { graphql, withPrefix } from "gatsby"
+import DocLayout from "../components/doclayout"
+import PageActions from "../components/PageActions"
+import SiteMenu from "../components/SiteMenu"
+import RenderMdx from "../components/RenderMdx"
+import NextPrev from "../components/NextPrev"
+
+import { Flex, View } from "@adobe/react-spectrum"
+import {
+  ActionButtons,
+  Contributors,
+  Link,
+} from "@adobe/parliament-ui-components"
+
+const findSelectedPageNextPrev = (pathname, pages) => {
+  const flat = flattenPages(pages)
+  const selectedPage = flat.find((page) => {
+    console.log(withPrefix(page.path))
+    return withPrefix(page.path) === pathname
+  })
+
+  return {
+    nextPage: flat[flat.indexOf(selectedPage) + 1],
+    previousPage: flat[flat.indexOf(selectedPage) - 1],
+  }
+}
+
+const flattenPages = (pages) => {
+  if (pages === null) {
+    return []
+  }
+
+  let flat = []
+  const find = (page) => {
+    flat.push(page)
+
+    if (page.pages) {
+      page.pages.forEach(find)
+    }
+  }
+
+  pages.forEach(find)
+
+  flat = flat.flat()
+  return flat.filter(
+    (page, index) => page.path && page.path !== flat[index + 1]?.path
+  )
+}
+
+const CoursesTemplate = ({ data, location, pageContext }) => {
+  const { file, parliamentNavigation, site } = data
+  const { siteMetadata } = site
+  const { sourceFiles } = siteMetadata
+  const { absolutePath, childMdx } = file
+  const { body, tableOfContents, timeToRead } = childMdx
+  const { contributors, gitRemote } = pageContext
+  const pathToFiles = sourceFiles.endsWith("/")
+    ? sourceFiles
+    : `${sourceFiles}/`
+  const relativePath = absolutePath.replace(pathToFiles, "")
+
+  const { nextPage, previousPage } = findSelectedPageNextPrev(
+    location.pathname,
+    parliamentNavigation.pages
+  )
+
+  console.log("currentPage ", location.pathname)
+
+  return (
+    <DocLayout
+      title={pageContext.seo}
+      location={location}
+      gitRemote={gitRemote}
+      currentPage={location.pathname}
+      pages={parliamentNavigation.pages}
+      sideNav={
+        <SiteMenu
+          currentPage={location.pathname}
+          gitRemote={gitRemote}
+          pages={parliamentNavigation.pages}
+        />
+      }
+      rightRail={
+        <aside
+          css={css`
+            position: fixed;
+            top: var(--spectrum-global-dimension-size-800);
+            height: 100%;
+          `}
+        >
+          <PageActions
+            gitRemote={gitRemote}
+            relativePath={relativePath}
+            tableOfContents={tableOfContents}
+            timeToRead={timeToRead}
+          />
+          Powered by{" "}
+          <Link href="https://developers.corp.adobe.com/parliament-docs/README.md">
+            Parliament
+          </Link>
+        </aside>
+      }
+    >
+      <div
+        css={css`
+          float: right;
+          z-index: 100;
+        `}
+      >
+        {gitRemote !== null ? (
+          <ActionButtons
+            gitUrl={`${gitRemote.protocol}://${gitRemote.resource}/${gitRemote.full_name}`}
+            filePath={relativePath}
+            branch={gitRemote.ref}
+          />
+        ) : (
+          ""
+        )}
+      </div>
+      <RenderMdx>{body}</RenderMdx>
+
+      <Flex
+        direction="column"
+        justifyContent="space-between"
+        gap="size-100"
+        marginTop="size-800"
+        marginBottom="size-400"
+      >
+        <View>
+          <NextPrev nextPage={nextPage} previousPage={previousPage} />
+        </View>
+        <View>
+          <Contributors
+            href={`${gitRemote.protocol}://${gitRemote.resource}/${gitRemote.full_name}/blob/${gitRemote.ref}/${relativePath}`}
+            contributors={contributors}
+            date={
+              contributors[0]
+                ? new Date(contributors[0].date).toLocaleDateString()
+                : new Date().toLocaleDateString()
+            }
+          />
+        </View>
+      </Flex>
+    </DocLayout>
+  )
+}
+
+export default CoursesTemplate
+
+export const query = graphql`
+  query CoursesTemplateQuery($id: String!) {
+    file(id: { eq: $id }) {
+      id
+      name
+      absolutePath
+      childMdx {
+        body
+        tableOfContents(maxDepth: 3)
+        timeToRead
+      }
+    }
+    parliamentNavigation {
+      pages
+    }
+    site {
+      siteMetadata {
+        sourceFiles
+      }
+    }
+  }
+`

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -11,6 +11,7 @@
  */
 
 /** @jsx jsx */
+import { useState } from "react"
 import { css, jsx } from "@emotion/react"
 import { graphql, withPrefix } from "gatsby"
 import DocLayout from "../components/doclayout"
@@ -18,6 +19,7 @@ import PageActions from "../components/PageActions"
 import SiteMenu from "../components/SiteMenu"
 import RenderMdx from "../components/RenderMdx"
 import NextPrev from "../components/NextPrev"
+import Checkmark from "@spectrum-icons/workflow/Checkmark"
 
 import { Flex, View } from "@adobe/react-spectrum"
 import {
@@ -29,7 +31,6 @@ import {
 const findSelectedPageNextPrev = (pathname, pages) => {
   const flat = flattenPages(pages)
   const selectedPage = flat.find((page) => {
-    console.log(withPrefix(page.path))
     return withPrefix(page.path) === pathname
   })
 
@@ -61,6 +62,20 @@ const flattenPages = (pages) => {
   )
 }
 
+const useLocalStorage = (key, initialValue) => {
+  const [visited, flipVisited] = useState(() => {
+    const item = window.localStorage.getItem(key);
+    return item ? JSON.parse(item) : initialValue;
+  });
+
+  const markVisited = () => {
+    flipVisited(true);
+    // TODO: persist somewhere other than localstore
+    window.localStorage.setItem(key, true);
+  };
+  return [visited, markVisited];
+}
+
 const CoursesTemplate = ({ data, location, pageContext }) => {
   const { file, parliamentNavigation, site } = data
   const { siteMetadata } = site
@@ -79,6 +94,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
   )
 
   console.log("currentPage ", location.pathname)
+  const [visited, markVisited] = useLocalStorage(location.pathname, false)
 
   return (
     <DocLayout
@@ -131,6 +147,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
           ""
         )}
       </div>
+      { visited && <Checkmark /> }
       <RenderMdx>{body}</RenderMdx>
 
       <Flex
@@ -141,7 +158,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
         marginBottom="size-400"
       >
         <View>
-          <NextPrev nextPage={nextPage} previousPage={previousPage} />
+          <NextPrev markProgression={markVisited} nextPage={nextPage} previousPage={previousPage} />
         </View>
         <View>
           <Contributors

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -71,7 +71,7 @@ const useLocalStorage = (key, initialValue) => {
 
   const markVisited = () => {
     flipVisited(true);
-    // TODO: persist somewhere other than localstore
+    // TODO: persist somewhere other than localstore?
     window.localStorage.setItem(key, true);
   };
   return [visited, markVisited];
@@ -139,17 +139,25 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
           z-index: 100;
         `}
       >
-        {gitRemote !== null ? (
-          <ActionButtons
-            gitUrl={`${gitRemote.protocol}://${gitRemote.resource}/${gitRemote.full_name}`}
-            filePath={relativePath}
-            branch={gitRemote.ref}
-          />
-        ) : (
-          ""
-        )}
+        <Flex alignItems="center">
+          { visited &&
+            <Flex alignItems="center">
+              <Checkmark />{" "}You have already read this module!
+            </Flex>
+          }
+
+          {gitRemote !== null ? (
+            <ActionButtons
+              gitUrl={`${gitRemote.protocol}://${gitRemote.resource}/${gitRemote.full_name}`}
+              filePath={relativePath}
+              branch={gitRemote.ref}
+            />
+          ) : (
+            ""
+          )}
+        </Flex>
       </div>
-      { visited && <Checkmark /> }
+
       <RenderMdx>{body}</RenderMdx>
 
       <Flex

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -14,6 +14,7 @@
 import { useState } from "react"
 import { css, jsx } from "@emotion/react"
 import { graphql, withPrefix } from "gatsby"
+import CourseNav from "../components/CourseNav"
 import DocLayout from "../components/doclayout"
 import PageActions from "../components/PageActions"
 import SiteMenu from "../components/SiteMenu"
@@ -108,6 +109,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
           currentPage={location.pathname}
           gitRemote={gitRemote}
           pages={parliamentNavigation.pages}
+          CustomNavComponent={CourseNav}
         />
       }
       rightRail={


### PR DESCRIPTION
## Description

- basic building blocks for course templates
- use local store just to note which course pages you have visited
- render course nav a specific way based on tree depth

Huge thanks to @macdonst for holding my hand through the majority of this!

## Related Issue

N/A

## Motivation and Context

To teach courses via Parliament, sourcing material from markdown files.

## How Has This Been Tested?

Local manual testing with a course repository (details in slack).

## Screenshots (if appropriate):

![Screen Shot 2021-04-20 at 7 14 49 PM](https://user-images.githubusercontent.com/1102319/115475068-d615eb00-a20c-11eb-81c5-17d753ccd013.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
