### PR TITLE
DEVEP-2694 Support custom header tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@adobe/gatsby-source-parliament": "^1.0.0",
     "@adobe/parliament-markdown-cleaner": "^1.3.0",
     "@adobe/parliament-source-changelog": "^0.0.4",
-    "@adobe/parliament-transformer-navigation": "^1.0.5",
+    "@adobe/parliament-transformer-navigation": "^1.1.0",
     "@adobe/parliament-ui-components": "^4.1.9",
     "@adobe/prism-adobe": "^1.0.3",
     "@adobe/react-spectrum": "^3.9.0",

--- a/src/components/doclayout.js
+++ b/src/components/doclayout.js
@@ -43,7 +43,7 @@ const DocLayout = ({
   sideNav,
   rightRail,
 }) => {
-  const { allSiteTabs, allHeaderTabs } = useStaticQuery(
+  const { allSiteTabs, allHeaderTabs, parliamentNavigation } = useStaticQuery(
     graphql`
       query {
         allHeaderTabs {
@@ -64,13 +64,18 @@ const DocLayout = ({
             }
           }
         }
+        parliamentNavigation {
+          tabs
+        }
       }
     `
   )
 
+  
   const tabs = [
     ...allSiteTabs.edges.map(({ node }) => node),
     ...allHeaderTabs.edges.map(({ node }) => node),
+    ...parliamentNavigation.tabs,
   ]
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,10 +77,10 @@
   dependencies:
     glob "^7.1.6"
 
-"@adobe/parliament-transformer-navigation@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@adobe/parliament-transformer-navigation/-/parliament-transformer-navigation-1.0.5.tgz#17ce68a777becec2ebc1eb1608cd5edfec694040"
-  integrity sha512-yMHbzSXmH/EeLN2NiNZ8XhGQltnC7CdC1z6kO120ij1AykR6ypBV1R3mkUJanuEyiE2AHilcVMJVExZJbBMTqA==
+"@adobe/parliament-transformer-navigation@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@adobe/parliament-transformer-navigation/-/parliament-transformer-navigation-1.1.0.tgz#60fdde0e968f80ca2976bc71d4eb42709f6bfa1a"
+  integrity sha512-Uk1tfb02ezoEXV1uM7AcGfmII0eDxHRl6xDUYNmjSBTczprXlZy8vWDs64G3xEnec7aElLlIk+PJe9xWmHtqWA==
   dependencies:
     yaml "^1.10.0"
 


### PR DESCRIPTION
## Description

Extend the headers to include custom defined tabs from the `manifest.yaml` file.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Change follows from: https://github.com/adobe/parliament-transformer-navigation/pull/9

## Motivation and Context

This change allows us to add custom tabs to the header. This is useful to link important external links (Swagger docs, Storybook etc)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested it locally.
- Change does not break if no tabs are specified in the manifest
- Change has been tested with and without the blog
- Change has been tested with absolute and relative hrefs

To enable tabs you will need to extend the `manifest.yaml` as such:

```
type: navigation
order: 1
title: Some Docs
pages:
  - title: Overview
    url: docs/guide/overview.md
  - title: Workflows
    url: docs/guide/workflows/introduction.md
tabs:
  - title: Swagger APIs
    url: https://host/api/v1/swagger-ui.html
  - title: Storybook
    url: https://storybook.host/?path=/story/welcome--page
  - title: Workflows
    url: docs/guide/workflows/introduction.md
```

## Screenshots (if appropriate):

### Without tabs (no degradation)
<img width="323" alt="Screenshot 2021-04-22 at 16 27 15" src="https://user-images.githubusercontent.com/1630716/115741558-c66ee180-a387-11eb-998c-0392907faabc.png">


### Without Blog
<img width="401" alt="Screenshot 2021-04-22 at 16 29 56" src="https://user-images.githubusercontent.com/1630716/115741890-0fbf3100-a388-11eb-8fd9-81d6f7d41257.png">


### With Blog

<img width="428" alt="Screenshot 2021-04-22 at 16 28 36" src="https://user-images.githubusercontent.com/1630716/115741632-d686c100-a387-11eb-9694-9a87a0533a1a.png">


### Behaviour with relative href
In this example the **workflow** tab has a local href, which get properly styled when clicked.

<img width="391" alt="Screenshot 2021-04-22 at 16 30 07" src="https://user-images.githubusercontent.com/1630716/115741908-13eb4e80-a388-11eb-847e-6d6f7e219e56.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
