### PR TITLE
Course Nav: Fixes & Enhancements

### DIFF
--- a/src/components/NextPrev.js
+++ b/src/components/NextPrev.js
@@ -18,17 +18,11 @@ import { Link } from "@adobe/parliament-ui-components"
 import ChevronLeft from "@spectrum-icons/workflow/ChevronLeft"
 import ChevronRight from "@spectrum-icons/workflow/ChevronRight"
 
-export const Prev = ({ prevPage, title, markProgression }) => {
+export const Prev = ({ prevPage, title }) => {
   if (!prevPage) {
     return null
   }
-
   let linkTitle = title ? title : prevPage.title
-
-  let clickCb = () => {}
-  if (markProgression) {
-    clickCb = markProgression
-  }
 
   return (
     <div>
@@ -75,7 +69,7 @@ export const Next = ({ nextPage, title, markProgression }) => {
       `}
     >
       <Link isQuiet={true}>
-        <GatsbyLink to={nextPage.path} rel="next">
+        <GatsbyLink to={nextPage.path} rel="next" onClick={markProgression}>
           <div
             css={css`
               display: flex;
@@ -108,7 +102,7 @@ const NextPrev = ({ nextPage, previousPage, markProgression }) =>
         `}
       >
 
-        <Prev prevPage={previousPage} markProgression={markProgression} />
+        <Prev prevPage={previousPage} />
         <Next nextPage={nextPage} markProgression={markProgression} />
       </div>
     </div>

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -13,6 +13,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/react"
 import "@spectrum-css/typography"
+import { navigate } from "gatsby"
 
 import "rsuite/dist/styles/rsuite-default.css"
 import { Steps } from "rsuite"
@@ -23,15 +24,29 @@ const styles = {
   verticalAlign: 'top'
 };
 
-const ProgressBar = ({ sections, currentIx }) => {
-  if (!sections) { return ""; }
+const step = (page) =>
+  <Steps.Item title={page.title} />
+
+const linkedStep = (page) =>
+  page.path
+    ? <Steps.Item onClick={() => { navigate(page.path) }} title=<a href="#">{page.title}</a> />
+    : step(page)
+
+const ProgressBar = ({ pages, currentIx }) => {
+  if (!pages) { return ""; }
 
   return (
     <div>
       <Steps current={currentIx ? currentIx : 0} vertical style={styles}>
-        {sections.map((sectionTitle) => (
-          <Steps.Item title={sectionTitle} />
-        ))}
+        {
+          pages.map((page, ix) => {
+            if (!page.path || currentIx === ix) {
+              return step(page)
+            }
+
+            return linkedStep(page)
+          })
+        }
       </Steps>
     </div>
   )

--- a/src/templates/course-catalog.js
+++ b/src/templates/course-catalog.js
@@ -36,11 +36,13 @@ import {
 } from "@adobe/parliament-ui-components"
 
 import { flattenPages } from "../util/index"
+import { completedModules } from "../util/course"
 
 // TODO: CLEAN - I am NOT proud of ANY of this
 // course.js template stores without leading slash
 const courseDir = (page) =>
   page.path.split("README.md").shift().replace(/\/$/, "")
+
 const coursePages = (pages, catalogDir) =>
   flattenPages(pages).filter((page) => {
     const pieces = page.path.split(catalogDir).pop().split("/")
@@ -52,17 +54,11 @@ const coursePages = (pages, catalogDir) =>
     )
   })
 
-const completedModules = (progress) =>
-  Object.keys(progress).filter((modulePath) =>
-    Object.keys(progress[modulePath]).some(
-      (version) => progress[modulePath][version]
-    )
-  )
-
 // TODO: actually match up versions
+//       and actually properly fetch all pages for coursePage
 const courseCompleted = (coursePage, progress) => {
-  console.log("courseCompleted?", coursePage, completedModules(progress))
-  return coursePage.pages.length <= completedModules(progress).length
+  // coursePage.pages does not include course intro README.md
+  return coursePage.pages.length+1 === completedModules(progress).length
 }
 
 const courseButton = (page) => (

--- a/src/util/course.js
+++ b/src/util/course.js
@@ -17,3 +17,16 @@ export const courseModulePages = (coursePages, course) =>
 
 export const courseModuleIx = (coursePages, modulePath) =>
   coursePages.map(p => p.path).indexOf(modulePath)
+
+// expected progress = structure described in util/localstore
+export const completedModules = (progress) => {
+  if (!progress) {
+    return []
+  }
+
+  return Object.keys(progress).filter((modulePath) =>
+    Object.keys(progress[modulePath]).some(
+      (version) => progress[modulePath][version]
+    )
+  )
+}

--- a/src/util/localstore.js
+++ b/src/util/localstore.js
@@ -52,9 +52,16 @@ export const useVersionedLocalStore = (localStoreKey, objKey, versionKey) => {
 
   // waits until after first render when window is available
   useEffect(() => {
+    // initial scaffolding
     let localStoreObj = window.localStorage.getItem(localStoreKey)
     let jsonObj = localStoreObj ? JSON.parse(localStoreObj) : {}
     let objVal = jsonObj[objKey] ? jsonObj[objKey] : {}
+
+    // ensure that localstore is initialized
+    jsonObj[objKey] = jsonObj[objKey] ? jsonObj[objKey] : {}
+    jsonObj[objKey][version] = objVal[version] || false
+    window.localStorage.setItem(localStoreKey, JSON.stringify(jsonObj))
+
     setBoolState(objVal[version] || false)
   }, [localStoreKey, objKey, version])
 


### PR DESCRIPTION
Fix for `NextPrev` bug introduced in #298 and add nav links in course progress.

## Description

- `NextPrev` callback was accidentally omitted during the refactor in #298 
- initialize localstore data with `false` visited keys on load
- allow users to navigate between modules using the progress wizard on course right-hand-side

## Related Issue

N/A

## Motivation and Context

Bugfix & QoL improvement.

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

![Screen Shot 2021-04-27 at 1 34 04 PM](https://user-images.githubusercontent.com/1102319/116286589-639d9180-a75d-11eb-948a-affd8ea847aa.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
