### PR TITLE
💄  DEVEP-2603: Issue with On this Page section since we disabled scro…

### DIFF
--- a/src/components/RightRail.js
+++ b/src/components/RightRail.js
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2021 Adobe. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react"
+
+const RightRail = ({ children }) => (
+  <aside
+    css={css`
+      position: fixed;
+      top: var(--spectrum-global-dimension-size-800);
+      height: 100%;
+      overflow-y: auto;
+    `}
+  >
+    {children}
+  </aside>
+)
+
+export default RightRail

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -8,6 +8,7 @@ import { SideNav, TableOfContents } from "@adobe/parliament-ui-components"
 
 import DocLayout from "../components/doclayout"
 import RenderMdx from "../components/RenderMdx"
+import RightRail from "../components/RightRail"
 
 export default function ChangeLogTemplate({ data, location, pageContext }) {
   const { mdx } = data
@@ -35,18 +36,12 @@ export default function ChangeLogTemplate({ data, location, pageContext }) {
         </View>
       }
       rightRail={
-        <aside
-          css={css`
-            position: fixed;
-            top: var(--spectrum-global-dimension-size-800);
-            height: 100%;
-          `}
-        >
+        <RightRail>
           <TableOfContents
             tableOfContents={tableOfContents}
             title="In this Update"
           />
-        </aside>
+        </RightRail>
       }
     >
       <View paddingX="size-300">

--- a/src/templates/course-catalog.js
+++ b/src/templates/course-catalog.js
@@ -21,6 +21,7 @@ import PageActions from "../components/PageActions"
 import SiteMenu from "../components/SiteMenu"
 import RenderMdx from "../components/RenderMdx"
 import SiteActionButtons from "../components/SiteActionButtons"
+import RightRail from "../components/RightRail"
 
 import {
   ActionButton,
@@ -160,13 +161,7 @@ const CourseCatalogTemplate = ({ data, location, pageContext }) => {
         />
       }
       rightRail={
-        <aside
-          css={css`
-            position: fixed;
-            top: var(--spectrum-global-dimension-size-800);
-            height: 100%;
-          `}
-        >
+        <RightRail>
           <PageActions
             gitRemote={gitRemote}
             relativePath={relativePath}
@@ -178,7 +173,7 @@ const CourseCatalogTemplate = ({ data, location, pageContext }) => {
           <Link href="https://developers.corp.adobe.com/parliament-docs/README.md">
             Parliament
           </Link>
-        </aside>
+        </RightRail>
       }
     >
       <div

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -35,6 +35,7 @@ import { useVersionedLocalStore } from "../util/localstore"
 import { Flex, View } from "@adobe/react-spectrum"
 import { Contributors, Link } from "@adobe/parliament-ui-components"
 import SiteActionButtons from "../components/SiteActionButtons"
+import RightRail from "../components/RightRail"
 
 const CoursesTemplate = ({ data, location, pageContext }) => {
   const { file, parliamentNavigation, site } = data
@@ -95,13 +96,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
         />
       }
       rightRail={
-        <aside
-          css={css`
-            position: fixed;
-            top: var(--spectrum-global-dimension-size-800);
-            height: 100%;
-          `}
-        >
+        <RightRail>
           <PageActions
             gitRemote={gitRemote}
             relativePath={relativePath}
@@ -117,7 +112,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
           <Link href="https://developers.corp.adobe.com/parliament-docs/README.md">
             Parliament
           </Link>
-        </aside>
+        </RightRail>
       }
     >
       <div

--- a/src/templates/markdown.js
+++ b/src/templates/markdown.js
@@ -25,6 +25,7 @@ import {
   stripManifestPath,
 } from "@adobe/parliament-ui-components"
 import SiteActionButtons from "../components/SiteActionButtons"
+import RightRail from "../components/RightRail"
 
 const MarkdownTemplate = ({ data, location, pageContext }) => {
   const { file, parliamentNavigation, site } = data
@@ -55,13 +56,7 @@ const MarkdownTemplate = ({ data, location, pageContext }) => {
         />
       }
       rightRail={
-        <aside
-          css={css`
-            position: fixed;
-            top: var(--spectrum-global-dimension-size-800);
-            height: 100%;
-          `}
-        >
+        <RightRail>
           <PageActions
             gitRemote={gitRemote}
             relativePath={relativePath}
@@ -72,7 +67,7 @@ const MarkdownTemplate = ({ data, location, pageContext }) => {
           <Link href="https://developers.corp.adobe.com/parliament-docs/README.md">
             Parliament
           </Link>
-        </aside>
+        </RightRail>
       }
     >
       <div

--- a/src/templates/quiz.js
+++ b/src/templates/quiz.js
@@ -26,6 +26,7 @@ import QuizMeter from "../components/QuizMeter"
 import QuizResults from "../components/QuizResults"
 import { findSelectedPageNextPrev } from "../util/index"
 import { useVersionedLocalStore } from "../util/localstore"
+import RightRail from "../components/RightRail"
 
 import { Flex, View, Well } from "@adobe/react-spectrum"
 import { Contributors, Link } from "@adobe/parliament-ui-components"
@@ -71,13 +72,7 @@ const QuizTemplate = ({ data, location, pageContext }) => {
         />
       }
       rightRail={
-        <aside
-          css={css`
-            position: fixed;
-            top: var(--spectrum-global-dimension-size-800);
-            height: 100%;
-          `}
-        >
+        <RightRail>
           <QuizMeter />
           <br />
           <Link href="https://jira.corp.adobe.com/projects/EON/issues">
@@ -88,7 +83,7 @@ const QuizTemplate = ({ data, location, pageContext }) => {
           <Link href="https://developers.corp.adobe.com/parliament-docs/README.md">
             Parliament
           </Link>
-        </aside>
+        </RightRail>
       }
     >
       <div


### PR DESCRIPTION
…lling it is overflowing on other components

<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable overflow Y when the table of contents on the right side of the page is too long

## Related Issue

DEVEP-2603

## Motivation and Context

On long pages you can't reach the bottom of the table of contents on the right hand side. By enabling an overflow on this section you can scroll down in the rare cases where the ToC is huge.

## How Has This Been Tested?

gatsby develop/build/serve

## Screenshots (if appropriate):

### Enough room for ToC

<img width="1476" alt="Screen Shot 2021-04-30 at 16 08 11" src="https://user-images.githubusercontent.com/353180/116749706-54257f00-a9cf-11eb-95aa-77b8a2910241.png">

### Not enough room for ToC

![parliament-right-rail](https://user-images.githubusercontent.com/353180/116749635-39530a80-a9cf-11eb-9f23-93dfb50a920b.gif)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
