### PR TITLE
🛠CI: include opened PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: CI for PRs
 on:
   pull_request:
-    types: [synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   ci-build:


### PR DESCRIPTION
Just realized that Actions were only being triggered if a PR was pushed to, not _opened_. 🤦‍♂️

## Description

Include `opened` & `reopened` events for CI Action workflow.

## Related Issue

N/A

## Motivation and Context

CI is nice. If it actually runs. LOL.

## How Has This Been Tested?

We'll see in this PR 😄 

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.