### PR TITLE
📓 Edu Templates: fix nav depth

### DIFF
--- a/src/components/SiteMenu.js
+++ b/src/components/SiteMenu.js
@@ -20,7 +20,11 @@ import { Nav, Search } from "@adobe/parliament-ui-components"
 
 import "./sitenav.css"
 
-const SiteMenu = ({ currentPage, pages }) => {
+// NOTE: spectrum _visually_ renders everything past 2 levels the same
+// i.e.: it seemingly flattens all of the pages. Consequently, depth only
+// controls the _number_ of pages rendered, allowing templates to logically
+// organize/group their pages. It does not visually change anything.
+const SiteMenu = ({ currentPage, pages , depth = 8 }) => {
   const { ParliamentSearchIndex } = useStaticQuery(
     graphql`
       query {
@@ -71,7 +75,7 @@ const SiteMenu = ({ currentPage, pages }) => {
           overflow-x: hidden;
         `}
       >
-        <Nav data={pages} selected={currentPage} />
+        <Nav data={pages} selected={currentPage} depth={depth} />
       </div>
     </div>
   )

--- a/src/templates/course-catalog.js
+++ b/src/templates/course-catalog.js
@@ -155,6 +155,7 @@ const CourseCatalogTemplate = ({ data, location, pageContext }) => {
         <SiteMenu
           currentPage={location.pathname}
           pages={parliamentNavigation.pages}
+          depth={2}
         />
       }
       rightRail={

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -90,6 +90,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
         <SiteMenu
           currentPage={location.pathname}
           pages={parliamentNavigation.pages}
+          depth={2}
         />
       }
       rightRail={


### PR DESCRIPTION
## Description

Pull in changes from https://github.com/adobe/parliament-ui-components/pull/172 to fix Edu template SiteNavs

## Related Issue

N/A

## Motivation and Context

Nav rendered all the things. 😢 

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.