### PR TITLE
Add @adobe/parliament-source-jsonschema to project

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -171,5 +171,12 @@ module.exports = {
         path: `${process.env.LOCAL_PROJECT_DIRECTORY}/changelog`,
       },
     },
+    {
+      resolve: `@adobe/parliament-source-jsonschema`,
+      options: {
+        path: `${process.env.LOCAL_PROJECT_DIRECTORY}`,
+        patterns: patterns,
+      },
+    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@adobe/gatsby-source-parliament": "^1.0.0",
     "@adobe/parliament-markdown-cleaner": "^1.5.4",
     "@adobe/parliament-source-changelog": "^0.0.4",
-    "@adobe/parliament-source-jsonschema": "^0.0.2",
+    "@adobe/parliament-source-jsonschema": "^0.0.3",
     "@adobe/parliament-transformer-navigation": "^1.2.0",
     "@adobe/parliament-ui-components": "^4.4.2",
     "@adobe/prism-adobe": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@adobe/gatsby-source-parliament": "^1.0.0",
     "@adobe/parliament-markdown-cleaner": "^1.5.4",
     "@adobe/parliament-source-changelog": "^0.0.4",
+    "@adobe/parliament-source-jsonschema": "^0.0.2",
     "@adobe/parliament-transformer-navigation": "^1.2.0",
     "@adobe/parliament-ui-components": "^4.4.2",
     "@adobe/prism-adobe": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,6 +79,14 @@
   dependencies:
     glob "^7.1.6"
 
+"@adobe/parliament-source-jsonschema@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@adobe/parliament-source-jsonschema/-/parliament-source-jsonschema-0.0.2.tgz#875fe74b62ec0a5284b273964b3aa0578c8b5be2"
+  integrity sha512-Q6w5zqo4LmStLu5mqdWOir/4hhLw9bvEid8fEe2iGw/jEqj+CCnrVT8IZ0jEr/tajfWBos7g/YYyFKDQPhBDJA==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "^9.0.7"
+    fast-glob "^3.2.5"
+
 "@adobe/parliament-transformer-navigation@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@adobe/parliament-transformer-navigation/-/parliament-transformer-navigation-1.2.0.tgz#637c3118ab148eaeb609421f28df20d30b6580a8"
@@ -200,7 +208,7 @@
     "@react-stately/collections" "^3.3.2"
     "@react-stately/data" "^3.4.0"
 
-"@apidevtools/json-schema-ref-parser@^9.0.6":
+"@apidevtools/json-schema-ref-parser@^9.0.6", "@apidevtools/json-schema-ref-parser@^9.0.7":
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz#64aa7f5b34e43d74ea9e408b90ddfba02050dde3"
   integrity sha512-QdwOGF1+eeyFh+17v2Tz626WX0nucd1iKOm6JUTUvCZdbolblCOOQCxGrQPY0f7jEhn36PiAWqZnsC2r5vmUWg==
@@ -9400,7 +9408,7 @@ fast-glob@^2.2.3:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4:
+fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4, fast-glob@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,10 @@
   dependencies:
     glob "^7.1.6"
 
-"@adobe/parliament-source-jsonschema@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@adobe/parliament-source-jsonschema/-/parliament-source-jsonschema-0.0.2.tgz#875fe74b62ec0a5284b273964b3aa0578c8b5be2"
-  integrity sha512-Q6w5zqo4LmStLu5mqdWOir/4hhLw9bvEid8fEe2iGw/jEqj+CCnrVT8IZ0jEr/tajfWBos7g/YYyFKDQPhBDJA==
+"@adobe/parliament-source-jsonschema@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@adobe/parliament-source-jsonschema/-/parliament-source-jsonschema-0.0.3.tgz#1a7c5f274a3aa02c634670062bebee38dcef77c9"
+  integrity sha512-XFV1wE62gqYWROydk/TXdLG4Hx7PzGsjDe74gOQ4cyNR0kAqJG568gBo6LrN+cPNzL97hqJef1JGgThutkRfiA==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.7"
     fast-glob "^3.2.5"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding @adobe/parliament-source-jsonschema to the project so we can source json schema files from the GraphQL database.

## Related Issue

DEVEP-2770

## Motivation and Context

So we can create pages based off of JSON Schema files

## How Has This Been Tested?

gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
