### PR TITLE
🎉  DEVEP-2784: Allow JSON Schema's to be embedded in markdown docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@adobe/gatsby-remark-afm": "^0.8.4",
     "@adobe/gatsby-source-github-file-contributors": "https://github.com/macdonst/gatsby-source-github-file-contributors.git",
     "@adobe/gatsby-source-parliament": "^1.0.0",
-    "@adobe/parliament-markdown-cleaner": "^1.5.5",
+    "@adobe/parliament-markdown-cleaner": "^1.5.6",
     "@adobe/parliament-source-changelog": "^0.0.4",
     "@adobe/parliament-source-jsonschema": "^0.0.4",
     "@adobe/parliament-transformer-navigation": "^1.2.0",

--- a/src/components/componentsMapping.js
+++ b/src/components/componentsMapping.js
@@ -20,6 +20,7 @@ import {
   Heading4,
   Heading5,
   Heading6,
+  JsonSchema,
   Link,
   List,
   Paragraph,
@@ -70,5 +71,6 @@ export const componentsMapping = {
   query: Query,
   headers: Headers,
   parameter: Parameter,
+  jsonschema: JsonSchema,
   ...inlineImages,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
     gatsby-source-filesystem "^2.1.19"
     rimraf "^2.6.2"
 
-"@adobe/parliament-markdown-cleaner@^1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@adobe/parliament-markdown-cleaner/-/parliament-markdown-cleaner-1.5.5.tgz#4bb57a3acd029b7eec7263b6e06a3a8ca8e78634"
-  integrity sha512-tEws4LRYfa1DlgNDzZmQhYHSK+Lbh6x8D+A5Xx5L9rkMmK+dOn8ogdRxduftdoeVqhkBLU4LKI42SSH/NTJ/lQ==
+"@adobe/parliament-markdown-cleaner@^1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@adobe/parliament-markdown-cleaner/-/parliament-markdown-cleaner-1.5.6.tgz#5c9f58d178911248d6ffee052bd4f92982cdf65c"
+  integrity sha512-634Ekrsg5c0eRP9V0/OrnUq9tee1cTTDiPk6KKZWGYtmRHMqA9RLXzpftzbQvP3z6p5bQwzczbdpvCFhdF23Ow==
   dependencies:
     "@svgr/core" "^5.5.0"
     download "^8.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow JSON Schema's to be embedded in markdown docs

## Related Issue

DEVEP-2784

## Motivation and Context

Just in case folks want to embed JSON Schema's in their markdown files

## How Has This Been Tested?

gatsby develop/build/serve

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
