### PR TITLE
💄  DEVEP-2819: JSON Schema properties section are not obvious in Chrome

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -30,10 +30,13 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
+summary {
+  display: list-item;
+}
+
 audio,
 canvas,
 progress,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes and issue where the ➡️  and ⬇️  don't show up for details/summary items.

## Related Issue

DEVEP-2819

## Motivation and Context

Without the icon it's hard to tell that the section is clickable.

## How Has This Been Tested?

gatsby develop/build/serve 

## Screenshots (if appropriate):

![Screen Shot 2021-06-21 at 10 26 22](https://user-images.githubusercontent.com/353180/122778598-22b48b80-d27b-11eb-844b-a51a96ac9ed2.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
