### PR TITLE
findSelectedPageNextPrev: remove dir requirement

### DIFF
--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -47,7 +47,6 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
   const { nextPage, previousPage } = findSelectedPageNextPrev(
     location.pathname,
     pages,
-    dirname,
     "Course",
     homePage
   )

--- a/src/templates/quiz.js
+++ b/src/templates/quiz.js
@@ -47,7 +47,6 @@ const QuizTemplate = ({ data, location, pageContext }) => {
   const { nextPage, previousPage } = findSelectedPageNextPrev(
     location.pathname,
     pages,
-    dirname,
     "Quiz",
     homePage
   )

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -17,7 +17,7 @@ export const pathDir = (path) => (path.split("/").slice(0, -1).join("/"))
 export const pageInSameDir = (page, dir) => (page && pathDir(page.path).indexOf(dir) !== -1)
 export const pageTitles = (pages) => pages.map((p) => p.title)
 
-export const findSelectedPageNextPrev = (pathname, pages, cwd, type = "", defaultHomePage = "/") => {
+export const findSelectedPageNextPrev = (pathname, pages, type = "", defaultHomePage = "/") => {
   const flat = flattenPages(pages)
   const selectedPage = flat.find((page) => {
     return withPrefix(page.path) === pathname
@@ -26,13 +26,13 @@ export const findSelectedPageNextPrev = (pathname, pages, cwd, type = "", defaul
   const previous = flat[flat.indexOf(selectedPage) - 1]
   let next = flat[flat.indexOf(selectedPage) + 1]
 
-  if (!next || !pageInSameDir(next, pathDir(pathname))) {
+  if (!next) {
     next = { path: defaultHomePage, title: `Complete ${type}` }
   }
 
   return {
     nextPage: next,
-    previousPage: pageInSameDir(previous, cwd) ? previous: null,
+    previousPage: previous,
   }
 }
 


### PR DESCRIPTION
this was written before the distinction between Curriculum vs Course was made
`dirname` no longer exists in the context where a course is an entire project

## Motivation and Context

Should fix this issue:

![Screen Shot 2021-10-19 at 1 49 20 PM](https://user-images.githubusercontent.com/1102319/137963972-43fea24a-a4b1-47a2-93e6-e0ae7e8dcc88.png)

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

See above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
