### PR TITLE
CourseNav: moduleCanBeNavigatedTo util arrow fx

### DIFF
--- a/src/components/CourseNav.js
+++ b/src/components/CourseNav.js
@@ -49,12 +49,18 @@ const navListItemLink = (liIndex, path, title, selected, completedModulePaths) =
 const navListItemDeadLink = (liIndex, path, title, selected, completedModulePaths) =>
   navListItemLink(liIndex, '#', title, selected, completedModulePaths)
 
+// here to get around page paths being pre-pended with different roots. Only valid in the context of projects
+// 🤷‍♂️
+const moduleCanBeNavigatedTo = (completedModulePaths, selected, modulePath) =>
+  selected.endsWith(modulePath) || modulePath.endsWith(selected) ||
+    completedModulePaths.some(path => path.endsWith(modulePath) || modulePath.endsWith(path))
+
 const nav = (data, selected, completedModulePaths) => {
     return (
       <ul className='spectrum-SideNav spectrum-SideNav--multiLevel'>
         {data.map(
           (node, index) => {
-            if (completedModulePaths.includes(node.path) || node.path == selected) {
+            if (moduleCanBeNavigatedTo(completedModulePaths, selected, node.path)) {
               return navListItemLink(index, node.path, node.title, selected, completedModulePaths)
             }
 

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -22,7 +22,7 @@ import CourseMenu from "../components/CourseMenu"
 import NextPrev from "../components/NextPrev"
 import Checkmark from "@spectrum-icons/workflow/Checkmark"
 
-import { findSelectedPageNextPrev } from "../util/index"
+import { findSelectedPageNextPrev, flattenPages } from "../util/index"
 import { completedModules } from "../util/course"
 import { useVersionedLocalStore } from "../util/localstore"
 
@@ -44,9 +44,10 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
     : `${sourceFiles}/`
   const relativePath = absolutePath.replace(pathToFiles, "")
   const { homePage, issues, pages } = parliamentNavigation
+  const flattenedPages = flattenPages(pages)
   const { nextPage, previousPage } = findSelectedPageNextPrev(
     location.pathname,
-    pages,
+    flattenedPages,
     "Course",
     homePage
   )
@@ -82,7 +83,7 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
         <CourseMenu
           completedModulePaths={completedModulePaths}
           currentPage={location.pathname}
-          pages={pages}
+          pages={flattenedPages}
         />
       }
       rightRail={

--- a/src/templates/quiz.js
+++ b/src/templates/quiz.js
@@ -23,7 +23,7 @@ import renderQuizAst from "../util/QuizRehype"
 import CourseMenu from "../components/CourseMenu"
 import QuizMeter from "../components/QuizMeter"
 import QuizResults from "../components/QuizResults"
-import { findSelectedPageNextPrev } from "../util/index"
+import { findSelectedPageNextPrev, flattenPages } from "../util/index"
 import { useVersionedLocalStore } from "../util/localstore"
 import RightRail from "../components/RightRail"
 import { completedModules } from "../util/course"
@@ -44,9 +44,10 @@ const QuizTemplate = ({ data, location, pageContext }) => {
     : `${sourceFiles}/`
   const relativePath = absolutePath.replace(pathToFiles, "")
   const { homePage, pages } = parliamentNavigation
+  const flattenedPages = flattenPages(pages)
   const { nextPage, previousPage } = findSelectedPageNextPrev(
     location.pathname,
-    pages,
+    flattenedPages,
     "Quiz",
     homePage
   )
@@ -83,7 +84,7 @@ const QuizTemplate = ({ data, location, pageContext }) => {
         <CourseMenu
           completedModulePaths={completedModulePaths}
           currentPage={location.pathname}
-          pages={pages}
+          pages={flattenedPages}
         />
       }
       rightRail={


### PR DESCRIPTION
Makes the enable/disable logic around nav links for courses a bit less strict; allows for prepends to page paths.

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
