### PR TITLE
More Link Fixes

### DIFF
--- a/src/components/CourseMenu.js
+++ b/src/components/CourseMenu.js
@@ -22,7 +22,7 @@ import "./sitenav.css"
 // i.e.: it seemingly flattens all of the pages. Consequently, depth only
 // controls the _number_ of pages rendered, allowing templates to logically
 // organize/group their pages. It does not visually change anything.
-const CourseMenu = ({ currentPage, pages, completedModulePaths }) => {
+const CourseMenu = ({ currentPageFullPath, pages, seenPaths }) => {
   return (
     <div
       css={css`
@@ -41,8 +41,8 @@ const CourseMenu = ({ currentPage, pages, completedModulePaths }) => {
       >
         <CourseNav
           data={pages}
-          selected={currentPage}
-          completedModulePaths={completedModulePaths}
+          selected={currentPageFullPath}
+          seenPaths={seenPaths}
         />
       </div>
     </div>
@@ -50,12 +50,15 @@ const CourseMenu = ({ currentPage, pages, completedModulePaths }) => {
 }
 
 CourseMenu.propTypes = {
-  currentPage: PropTypes.string,
-  forceMobile: PropTypes.bool,
+  currentPageFullPath: PropTypes.string,
+  seenPaths: PropTypes.array,
+  pages: PropTypes.array,
 }
 
 CourseMenu.defaultProps = {
-  currentPage: "",
+  currentPageFullPath: "/",
+  seenPaths: [],
+  pages: PropTypes.array,
   forceMobile: false,
 }
 

--- a/src/components/CourseNav.js
+++ b/src/components/CourseNav.js
@@ -10,6 +10,7 @@ governing permissions and limitations under the License.
 */
 import React from 'react'
 import PropTypes from 'prop-types'
+import { Link as GatsbyLink } from "gatsby"
 
 import '@spectrum-css/sidenav'
 
@@ -36,13 +37,13 @@ const navItemClass = (path, selectedPathUri, completedModulePaths) => {
 
 const navListItemLink = (liIndex, path, title, selected, completedModulePaths) => (
   <li className={navItemClass(path, selected, completedModulePaths)} key={liIndex}>
-    <a
-      href={path}
+    <GatsbyLink
+      to={path}
       className='spectrum-SideNav-itemLink'
       style={liStyles}
     >
       {title}
-    </a>
+    </GatsbyLink>
   </li>
 )
 

--- a/src/components/CourseNav.js
+++ b/src/components/CourseNav.js
@@ -10,9 +10,11 @@ governing permissions and limitations under the License.
 */
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link as GatsbyLink } from "gatsby"
+import { withPrefix, Link as GatsbyLink } from "gatsby"
 
 import '@spectrum-css/sidenav'
+
+const liStyles = { paddingLeft: `calc(var(--spectrum-global-dimension-size-150))` }
 
 const isPathSelected = (path, selected) => {
     const compare = selected.endsWith('/')
@@ -21,22 +23,21 @@ const isPathSelected = (path, selected) => {
     return path === compare
 }
 
-const liStyles = { paddingLeft: `calc(var(--spectrum-global-dimension-size-150))` }
-
-const navItemClass = (path, selectedPathUri, completedModulePaths) => {
+const navItemClass = (path, selectedPathUri, seenPaths) => {
   let className = isPathSelected(path, selectedPathUri)
                   ? 'spectrum-SideNav-item is-selected'
                   : 'spectrum-SideNav-item'
 
-  if (completedModulePaths.includes(path) || selectedPathUri === path) {
+  const fullPath = withPrefix(path)
+  if (seenPaths.includes(fullPath) || selectedPathUri === fullPath) {
     return className
   }
 
   return `${className} is-disabled`
 }
 
-const navListItemLink = (liIndex, path, title, selected, completedModulePaths) => (
-  <li className={navItemClass(path, selected, completedModulePaths)} key={liIndex}>
+const navListItemLink = (liIndex, path, title, selected, seenPaths) => (
+  <li className={navItemClass(path, selected, seenPaths)} key={liIndex}>
     <GatsbyLink
       to={path}
       className='spectrum-SideNav-itemLink'
@@ -47,45 +48,53 @@ const navListItemLink = (liIndex, path, title, selected, completedModulePaths) =
   </li>
 )
 
-const navListItemDeadLink = (liIndex, path, title, selected, completedModulePaths) =>
-  navListItemLink(liIndex, '#', title, selected, completedModulePaths)
+const navListItemDeadLink = (liIndex, path, title, selected, seenPaths) =>
+  navListItemLink(liIndex, '#', title, selected, seenPaths)
 
-// here to get around page paths being pre-pended with different roots. Only valid in the context of projects
-// 🤷‍♂️
-const moduleCanBeNavigatedTo = (completedModulePaths, selected, modulePath) =>
-  selected.endsWith(modulePath) || modulePath.endsWith(selected) ||
-    completedModulePaths.some(path => path.endsWith(modulePath) || modulePath.endsWith(path))
+const moduleCanBeNavigatedTo = (seenPaths, currentFullPath, nodePathWithPrefix) =>
+    currentFullPath ===  nodePathWithPrefix ||
+      seenPaths.some(path => path === nodePathWithPrefix)
 
-const nav = (data, selected, completedModulePaths) => {
-    return (
-      <ul className='spectrum-SideNav spectrum-SideNav--multiLevel'>
-        {data.map(
-          (node, index) => {
-            if (moduleCanBeNavigatedTo(completedModulePaths, selected, node.path)) {
-              return navListItemLink(index, node.path, node.title, selected, completedModulePaths)
-            }
+const nav = (data, selected, seenPaths) => {
+  return (
+    <ul className='spectrum-SideNav spectrum-SideNav--multiLevel'>
+      {data.map(
+        (node, index) => {
+          const { path, title } = node
+          const nodeFullPath = withPrefix(path)
 
-            return navListItemDeadLink(index, node.path, node.title, selected, completedModulePaths)
+          if (moduleCanBeNavigatedTo(seenPaths, selected, nodeFullPath)) {
+            return navListItemLink(index, path, title, selected, seenPaths)
           }
-        )}
-      </ul>
-    )
+
+          return navListItemDeadLink(index, path, title, selected, seenPaths)
+        }
+      )}
+    </ul>
+  )
 }
 
+/**
+ * data - array of page objects with path & title attributes.
+ *        Path attribute does NOT have prefixes
+ *        (pulled directly from GraphQL query)
+ * selected - FULL path of the page that user is currently on (includes prefix)
+ * seenPaths - array of FULL page paths (currently from local store, which stores full paths)
+ */
 const CourseNav = ({ data = [], selected = '', ...props }) => {
-  const { completedModulePaths } = props
+  const { seenPaths } = props
   const defaultFocus = selected.charAt(0) === '/' ? selected : `/${selected}`
   return (
-        <nav aria-label='Course Side Navigation' {...props}>
-          {nav(data, defaultFocus, completedModulePaths)}
-        </nav>
-      )
+    <nav aria-label='Course Side Navigation' {...props}>
+      {nav(data, defaultFocus, seenPaths)}
+    </nav>
+  )
 }
 
 CourseNav.propTypes = {
     data: PropTypes.array,
     selected: PropTypes.string,
-    depth: PropTypes.number
+    seenPaths: PropTypes.array,
 }
 
 export { CourseNav }

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -81,8 +81,8 @@ const CoursesTemplate = ({ data, location, pageContext }) => {
       pages={pages}
       sideNav={
         <CourseMenu
-          completedModulePaths={completedModulePaths}
-          currentPage={location.pathname}
+          seenPaths={completedModulePaths}
+          currentPageFullPath={location.pathname}
           pages={flattenedPages}
         />
       }

--- a/src/templates/quiz.js
+++ b/src/templates/quiz.js
@@ -82,8 +82,8 @@ const QuizTemplate = ({ data, location, pageContext }) => {
       pages={pages}
       sideNav={
         <CourseMenu
-          completedModulePaths={completedModulePaths}
-          currentPage={location.pathname}
+          seenPaths={completedModulePaths}
+          currentPageFullPath={location.pathname}
           pages={flattenedPages}
         />
       }


### PR DESCRIPTION
## Description

- use `gatsby.Link` for course nav
- rename a few props in `CourseNav` and `CourseMenu` so it's more obvious which variables are being used for what
- use `withPrefix` to account for localstore containing page fullpaths; page objects themselves only have page paths specified in their manifests, no prefixes.

## Motivation and Context

Fixes a bug with the CourseNav in course templates.

## How Has This Been Tested?

Locally (build + `yarn start`)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
