### PR TITLE
Add spacing to improve readability for TOC sidebar

### DIFF
--- a/src/components/PageActions.js
+++ b/src/components/PageActions.js
@@ -21,9 +21,9 @@ const rewriteToc = (tableOfContents) => {
       /<ul/g,
       `<ul class='spectrum-Body--sizeM' style="list-style: none; padding-left: var(--spectrum-global-dimension-static-size-200); margin-left: 0; margin-bottom: 0; margin-top: 0;"`
     )
-    .replace(/<li/g, '<li style="margin-bottom: 0"')
+    .replace(/<li/g, '<li style="margin-bottom: var(--spectrum-global-dimension-static-size-100)"')
     .replace(/<a/g, `<a class="spectrum-Link spectrum-Link--quiet"`)
-    .replace(/<p/g, '<p style="margin-bottom: 0"')
+    .replace(/<p/g, '<p style="margin-bottom: var(--spectrum-global-dimension-static-size-100)"')
 }
 
 const PageActions = ({ tableOfContents, timeToRead }) => {


### PR DESCRIPTION
## Description

- Improved readability of TOC sidebar by adding some padding between each item

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

- Client originally asked for line-wrapping around each item but since that was resolved in a previous PR, this PR aims to improve the readability, especially for longer TOC items.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

**Before**
<img width="1359" alt="Screen Shot 2021-11-18 at 5 31 33 PM" src="https://user-images.githubusercontent.com/8335579/142511046-705996e3-8fee-437b-ba14-1c35ce073f16.png">

**After**
<img width="1382" alt="Screen Shot 2021-11-18 at 5 31 44 PM" src="https://user-images.githubusercontent.com/8335579/142511052-fcef73e3-10dc-4318-9fbd-9469139eb1e0.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
