### PR TITLE
Fix ToC data structure

### DIFF
--- a/src/components/PageActions.js
+++ b/src/components/PageActions.js
@@ -23,38 +23,28 @@ const rewriteToc = (headings) => {
       url: `#${heading.id}`,
       title: heading.value,
       depth: heading.depth,
+      items: [],
     }
   }
 
+  let current;
   while (headings.length) {
-    let current = formatHeading(headings.shift())
-    let mainLength = items.length
-    if (mainLength) {
-      let last = items[mainLength - 1]
-      if (current.depth <= last.depth) {
-        items.push(current)
-      } else {
-        let secLength = items[mainLength - 1]?.items?.length
-        if (secLength) {
-          let last = items[mainLength - 1].items[secLength - 1]
-          if (current.depth <= last.depth) {
-            items[mainLength - 1].items.push(current)
-          } else {
-            items[mainLength - 1]?.items[secLength - 1]?.items
-              ? items[mainLength - 1].items[secLength - 1].items.push(current)
-              : (items[mainLength - 1].items[secLength - 1].items = [current])
-          }
-        } else {
-          items[mainLength - 1].items
-            ? items[mainLength - 1].items.push(current)
-            : (items[mainLength - 1].items = [current])
-        }
-      }
+    let parent = current;
+    current = formatHeading(headings.shift());
+
+    // find nearest possible parent heading
+    while (current.depth <= parent?.depth) {
+      parent = parent.parent;
+    }
+
+    if (parent) {
+      current.parent = parent;
+      parent.items.push(current);
     } else {
-      items.push(current)
+      items.push(current);
     }
   }
-  return { items: items }
+  return { items }
 }
 
 const PageActions = ({ headings, timeToRead }) => {


### PR DESCRIPTION
Fixes the data structure that is passed for the "On This Page" Table of Contents component

## Description
* Re-worked the function which nests the headings for consumption by the ToC component

## Related Issue
#398
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested with affected pages and some test pages with various degrees of nesting/headings.

## Screenshots (if appropriate):
<img width="325" alt="image" src="https://user-images.githubusercontent.com/1596686/165875508-0643a8bd-1263-44b7-b1c7-ac19bd207c1f.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
