### PR TITLE
Add HTML title fallback for non-manifested pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -171,6 +171,9 @@ exports.createPages = async ({ actions, graphql }) => {
                 author
                 template
               }
+              headings(depth: h1) {
+                value
+              }
             }
           }
         }
@@ -415,6 +418,14 @@ exports.createPages = async ({ actions, graphql }) => {
 
         if (node.fields.slug !== "") {
           let seo = searchTree(parliamentNavigation.pages, node.fields.slug)
+
+          if (seo === null || seo.trim() === "") {
+            const { headings } = node
+
+            // Fallback to first h1 heading
+            seo = headings?.length > 0 ? headings[0].value : seo
+          }
+
           createPage({
             path: node.fields.slug,
             component: template,


### PR DESCRIPTION
## Description
Attempts to add HTML title fallback for pages that are not listed in `manifest.yaml`, or that are missing titles.

## Related Issue
Fixes #402 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
### Before
![image](https://user-images.githubusercontent.com/11140840/192346104-6f35970f-a549-4b33-9546-ca12eea8c0dc.png)
### After
![image](https://user-images.githubusercontent.com/11140840/192347542-bcc5a0b0-2212-483b-921e-2091da32c424.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
