### PR TITLE
disable ligatures in monospace code blocks.

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -321,8 +321,8 @@ figure {
 
 code[class*="language-"],
 pre[class*="language-"] {
-  white-space: pre-wrap !important;
   font-feature-settings: "liga" 0;
+  white-space: pre-wrap !important;
 }
 
 table {

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -322,6 +322,7 @@ figure {
 code[class*="language-"],
 pre[class*="language-"] {
   white-space: pre-wrap !important;
+  font-feature-settings: "liga" 0;
 }
 
 table {


### PR DESCRIPTION
## Description

turns off font ligatures in code blocks.

## Related Issue

#413

## Motivation and Context

It looks bad and is harder to read.

## How Has This Been Tested?

In the brower, via dev-tools on the class declaration in question.

## Screenshots (if appropriate):

![image](https://github.com/adobe/parliament-client-template/assets/719818/04c498ec-8875-4a37-be14-f78c83d0c872)

Note `font-variant-ligatures: no-common-ligatures` does not help.
![image](https://github.com/adobe/parliament-client-template/assets/719818/0730ddd9-e9de-4a4e-9bcc-60356fa83344)

(also note the screen-shot text was also edited in dev-tools, I don't remember where I found the original issue).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 🤞 
